### PR TITLE
feat(windowservice): Made the windowService subjects private, added TSDoc and fix tests

### DIFF
--- a/projects/utils/package-lock.json
+++ b/projects/utils/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@studiohyperdrive/ngx-utils",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1
 }

--- a/projects/utils/package.json
+++ b/projects/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiohyperdrive/ngx-utils",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "peerDependencies": {
     "@angular/common": "^11.2.1",
     "@angular/core": "^11.2.1"

--- a/projects/utils/src/lib/window-service/window.service.mock.ts
+++ b/projects/utils/src/lib/window-service/window.service.mock.ts
@@ -13,6 +13,7 @@ export const windowMock = (spy: unknown) => ({
 	defaultView: {
 		scrollTo: () => null,
 		innerWidth: 720,
+		addEventListener: spy,
 	},
 });
 

--- a/projects/utils/src/lib/window-service/window.service.spec.ts
+++ b/projects/utils/src/lib/window-service/window.service.spec.ts
@@ -26,8 +26,8 @@ describe('WindowService', () => {
 		});
 
 		describe('construct', () => {
-			it('should set the width$ BehaviourSubject to a default value of 1200 for SSR', () => {
-				expect(service.width$.getValue()).toBe(1200);
+			it('should set the width$ BehaviorSubject to a default value of 1200 for SSR', () => {
+				expect((service as any).widthSubject$.getValue()).toBe(1200);
 			});
 		});
 
@@ -46,12 +46,13 @@ describe('WindowService', () => {
 
 	describe('with a document', () => {
 		let service: WindowService;
+		const window = windowMock(jasmine.createSpy());
 
 		beforeEach(async () => {
 			await TestBed.configureTestingModule({
 				providers: [{
 					provide: DOCUMENT,
-					useValue: windowMock,
+					useValue: window,
 				}, {
 					provide: PLATFORM_ID,
 					useValue: 'browser',
@@ -64,8 +65,8 @@ describe('WindowService', () => {
 		});
 
 		describe('construct', () => {
-			it('should set the width$ BehaviourSubject to the value of the window-width', () => {
-				expect(service.width$.getValue()).toBe(windowMock.defaultView.innerWidth);
+			it('should set the width$ BehaviorSubject to the value of the window-width', () => {
+				expect((service as any).widthSubject$.getValue()).toBe(windowMock(jasmine.createSpy()).defaultView.innerWidth);
 			});
 		});
 
@@ -88,7 +89,7 @@ describe('WindowService', () => {
 
 		describe('scrollListeners', () => {
 			it('should have called addEventListeners', () => {
-				expect(windowMock.addEventListener).toHaveBeenCalled();
+				expect(window.addEventListener).toHaveBeenCalled();
 			});
 		});
 


### PR DESCRIPTION
When using the windowService in a project I noticed that I could just push a new value to the `width$`, whilst that property should only be updated when the window resizes, and I as a user should not be able to push anything on it.

I went through the code and saw that the BehaviorSubjects were public, so I made those private and returned the needed values as Observables. I also added an Observable for the current scroll position, which seemed useful to me when we for instance want to start loading specific content at specific scroll positions.

While I was at it, I added some TSDoc so that the doc in the readme would also be available in VSCode
![afbeelding](https://user-images.githubusercontent.com/10544531/121475682-07699680-c9c6-11eb-9427-35eb211ee339.png).

Finally I noticed the test weren't working so I fixed those as well.