### PR TITLE
feat(forms): Update name of Validators class - ngx-forms

### DIFF
--- a/projects/forms/src/lib/validators/validators.ts
+++ b/projects/forms/src/lib/validators/validators.ts
@@ -16,7 +16,7 @@ import { extendedEmailValidator } from './email/extended-email.validator';
  * Exported Class
  */
 
-export class Validators {
+export class NgxValidators {
 	/**
 	 * A stricter validator for e-mail validation
 	 *

--- a/projects/forms/src/public-api.ts
+++ b/projects/forms/src/public-api.ts
@@ -2,4 +2,4 @@
  * Public API Surface of forms
  */
 
-export { Validators } from './lib/validators/validators';
+export { NgxValidators } from './lib/validators/validators';


### PR DESCRIPTION
I did a quick test with the Validators class object in Stackblitz and noticed that then I had to `import as` if I wanted to use our validators and the default Angular validators.

To make sure that it does not become an issue in the future, I've renamed it to NgxValidators.