### PR TITLE
feat(forms): Add depended required validator - ngx-forms

### DIFF
--- a/projects/forms/src/lib/validators/depended-required/depended-required.validator.spec.ts
+++ b/projects/forms/src/lib/validators/depended-required/depended-required.validator.spec.ts
@@ -1,0 +1,104 @@
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { dependedRequiredValidator } from './depended-required.validator';
+
+describe('DependedRequiredValidator', () => {
+	let form: FormGroup;
+	let formWithMatchValue: FormGroup;
+	let shouldBeTest;
+	beforeEach(() => {
+		shouldBeTest = (value: any) => {
+			return value === 'TEST';
+		};
+
+		form = new FormGroup(
+			{
+				a: new FormControl(''),
+				b: new FormControl(''),
+				c: new FormControl(''),
+			},
+			dependedRequiredValidator(['b', 'c'], 'a')
+		);
+
+		formWithMatchValue = new FormGroup(
+			{
+				a: new FormControl(''),
+				b: new FormControl(''),
+				c: new FormControl(''),
+			},
+			dependedRequiredValidator(['b', 'c'], 'a', shouldBeTest)
+		);
+	});
+
+	it('should not give an error', () => {
+		expect(form.valid).toEqual(true);
+
+		form.patchValue({
+			a: true,
+			b: 'It',
+			c: 'works',
+		});
+
+		expect(form.valid).toEqual(true);
+
+		form.patchValue({
+			a: false,
+			b: 'It',
+			c: 'works',
+		});
+
+		expect(form.valid).toEqual(true);
+
+		form.patchValue({
+			a: 0,
+			b: 'It',
+			c: 'works',
+		});
+
+		expect(form.valid).toEqual(true);
+
+		formWithMatchValue.patchValue({
+			a: 'TEST',
+			b: 'It',
+			c: 'works',
+		});
+
+		expect(form.valid).toEqual(true);
+	});
+
+	it('should give an error', () => {
+		form.patchValue({ a: true });
+		expect(form.valid).toEqual(false);
+		expect(form.get('b').valid).toEqual(false);
+		expect(form.get('c').valid).toEqual(false);
+		expect(form.errors).toEqual({ hasDependedRequiredError: ['b', 'c'] });
+		expect(form.get('c').errors).toEqual({ required: true });
+		expect(form.get('b').errors).toEqual({ required: true });
+
+		form.patchValue({ a: false });
+		expect(form.valid).toEqual(false);
+		expect(form.get('b').valid).toEqual(false);
+		expect(form.get('c').valid).toEqual(false);
+		expect(form.errors).toEqual({ hasDependedRequiredError: ['b', 'c'] });
+		expect(form.get('c').errors).toEqual({ required: true });
+		expect(form.get('b').errors).toEqual({ required: true });
+
+		form.patchValue({ a: 0 });
+		expect(form.valid).toEqual(false);
+		expect(form.get('b').valid).toEqual(false);
+		expect(form.get('c').valid).toEqual(false);
+		expect(form.errors).toEqual({ hasDependedRequiredError: ['b', 'c'] });
+		expect(form.get('c').errors).toEqual({ required: true });
+		expect(form.get('b').errors).toEqual({ required: true });
+
+		formWithMatchValue.patchValue({ a: 'TEST' });
+		expect(formWithMatchValue.valid).toEqual(false);
+		expect(formWithMatchValue.get('b').valid).toEqual(false);
+		expect(formWithMatchValue.get('c').valid).toEqual(false);
+		expect(formWithMatchValue.errors).toEqual({
+			hasDependedRequiredError: ['b', 'c'],
+		});
+		expect(formWithMatchValue.get('c').errors).toEqual({ required: true });
+		expect(formWithMatchValue.get('b').errors).toEqual({ required: true });
+	});
+});

--- a/projects/forms/src/lib/validators/depended-required/depended-required.validator.ts
+++ b/projects/forms/src/lib/validators/depended-required/depended-required.validator.ts
@@ -1,0 +1,72 @@
+import { FormGroup } from '@angular/forms';
+
+import { clearFormError, setFormError } from '../utils';
+
+const EMPTY_SET = new Set([undefined, null, '']);
+
+/**
+ * FormGroup validator which checks if an array of controls in the control are filled in if the depended control is filled in
+ *
+ * @param controls - An array of controls.
+ * @param dependedControlKey - A control within the group which the other controls depend on.
+ * @param matchFunction - Optional function the dependedControl should check
+ */
+export const dependedRequiredValidator = <KeyType extends string = string>(
+	controls: KeyType[],
+	dependedControlKey: KeyType,
+	matchFunction?: (data: any) => boolean
+) => {
+	return (form: FormGroup): { hasDependedRequiredError: string[] } | null => {
+		// Iben: Make a set so we know which controls are not filled in
+		const keysWithErrors = new Set<KeyType>();
+		const dependedControl = form.get(dependedControlKey);
+
+		// Iben: If the control is not filled in or the value doesn't match, we do an early exit and remove all potential required errors
+		if (
+			!dependedControl ||
+			!(matchFunction
+				? matchFunction(dependedControl.value)
+				: !EMPTY_SET.has(dependedControl.value))
+		) {
+			for (const key of controls) {
+				const control = form.get(key);
+
+				// Continue if control does not exist
+				if (!control) {
+					continue;
+				}
+
+				clearFormError(control, 'required');
+			}
+
+			return null;
+		}
+
+		// Iben: Set an overall error so we can see if all controls are filled in or not
+		let hasError = false;
+
+		for (const key of controls) {
+			const control = form.get(key);
+
+			// Iben: Continue if control does not exist
+			if (!control) {
+				continue;
+			}
+
+			hasError = hasError || EMPTY_SET.has(control.value);
+
+			// Iben: If the control is not filled in we set a required error, if not, we remove it
+			if (!EMPTY_SET.has(control.value)) {
+				clearFormError(control, 'required');
+				keysWithErrors.delete(key);
+			} else {
+				setFormError(control, 'required');
+				keysWithErrors.add(key);
+			}
+		}
+
+		const errors = Array.from(keysWithErrors);
+
+		return hasError ? { hasDependedRequiredError: errors } : null;
+	};
+};

--- a/projects/forms/src/lib/validators/email/extended-email.validator.spec.ts
+++ b/projects/forms/src/lib/validators/email/extended-email.validator.spec.ts
@@ -1,28 +1,28 @@
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 
-import { Validators } from '../validators';
+import { NgxValidators } from '../validators';
 
 describe('Extended Email Validator', () => {
 	it('should throw an error if e-mail is not valid', () => {
 		const control1 = new UntypedFormControl('test');
 		const control2 = new UntypedFormControl('test@test');
 
-		expect(Validators.extendedEmail(control1)).toEqual({ extendedEmail: true });
-		expect(Validators.extendedEmail(control2)).toEqual({ extendedEmail: true });
+		expect(NgxValidators.extendedEmail(control1)).toEqual({ extendedEmail: true });
+		expect(NgxValidators.extendedEmail(control2)).toEqual({ extendedEmail: true });
 	});
 
 	it('should not throw an error if e-mail is valid', () => {
 		const control1 = new UntypedFormControl(''); // Should be valid, use Validators.required for this
 		const control2 = new UntypedFormControl('test@test.be');
 
-		expect(Validators.extendedEmail(control1)).toBeNull();
-		expect(Validators.extendedEmail(control2)).toBeNull();
+		expect(NgxValidators.extendedEmail(control1)).toBeNull();
+		expect(NgxValidators.extendedEmail(control2)).toBeNull();
 	});
 
 	it('should work as validator in a reactive form', () => {
 		const form = new UntypedFormGroup({
-			email1: new UntypedFormControl('', [Validators.extendedEmail]),
-			email2: new UntypedFormControl('', [Validators.extendedEmail]),
+			email1: new UntypedFormControl('', [NgxValidators.extendedEmail]),
+			email2: new UntypedFormControl('', [NgxValidators.extendedEmail]),
 		});
 
 		form.get('email1').setValue('test@test');

--- a/projects/forms/src/lib/validators/validators.ts
+++ b/projects/forms/src/lib/validators/validators.ts
@@ -10,6 +10,7 @@ import {
 	AtLeastOneRequiredValidatorOptions,
 	atLeastOneRequiredValidator,
 } from './at-least-one-required/at-least-one-required.validator';
+import { dependedRequiredValidator } from './depended-required/depended-required.validator';
 import { extendedEmailValidator } from './email/extended-email.validator';
 
 /**
@@ -48,6 +49,21 @@ export class NgxValidators {
 		options?: AtLeastOneRequiredValidatorOptions<KeyType>
 	): ValidatorFn {
 		return atLeastOneRequiredValidator<KeyType>(options);
+	}
+
+	/**
+	 * FormGroup validator which checks if an array of controls in the control are filled in if the depended control is filled in
+	 *
+	 * @param controls - An array of controls.
+	 * @param dependedControlKey - A control within the group which the other controls depend on.
+	 * @param matchFunction - Optional function the dependedControl should check
+	 */
+	static dependedRequired<KeyType extends string = string>(
+		controls: KeyType[],
+		dependedControlKey: KeyType,
+		matchFunction?: (data: any) => boolean
+	): ValidatorFn {
+		return dependedRequiredValidator<KeyType>(controls, dependedControlKey, matchFunction);
 	}
 
 	// Add other custom validators :-)


### PR DESCRIPTION
Adds a FormGroup validator to validate if a set of controls are required in case a different control has been filled in. By default it checks on whether the control's value is filled in, but a specific match function can be provided in case a set of controls becomes required once a certain option is selected.