### PR TITLE
feat(ngx-store): Export remaining needed interfaces and add ability to pass a selectId function - ngx-store

### DIFF
--- a/projects/store/package-lock.json
+++ b/projects/store/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiohyperdrive/ngx-store",
-  "version": "16.0.1",
+  "version": "16.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/store/package.json
+++ b/projects/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiohyperdrive/ngx-store",
-  "version": "16.0.1",
+  "version": "16.0.2",
   "peerDependencies": {
     "@angular/common": "^16.1.0",
     "@angular/core": "^16.1.0",

--- a/projects/store/src/lib/store/interfaces/index.ts
+++ b/projects/store/src/lib/store/interfaces/index.ts
@@ -2,3 +2,4 @@ export { BasicEntityAdapterActions, BasicEntityState } from './entity-adapter-re
 export * from './base-store';
 export * from './entity-store-assets';
 export * from './store';
+export * from './store-generator';

--- a/projects/store/src/lib/store/interfaces/store-generator.ts
+++ b/projects/store/src/lib/store/interfaces/store-generator.ts
@@ -1,0 +1,45 @@
+import { ActionReducer, Action } from '@ngrx/store';
+import { IdSelector } from '@ngrx/entity';
+
+import { BaseStoreAssets } from './base-store';
+import { EntityStoreAssets } from './entity-store-assets';
+
+/**
+ * These objects will be used as a blueprint for our store slices
+ *
+ * @template SliceKey - The keys of our store
+ */
+export interface StoreAssetsOptions<SliceKey extends string | number | symbol> {
+	subSlice: SliceKey;
+	generator:
+		| ((slice: string, selectId?: IdSelector<any>) => EntityStoreAssets<any>)
+		| ((slice: string) => BaseStoreAssets<any>);
+
+	selectId?: IdSelector<any>;
+}
+
+// Iben: The base type for our flow assets which we'll pass to the create generator
+export type StoreFlowAssets = Record<string, EntityStoreAssets<any> | BaseStoreAssets<any>>;
+
+// Iben: Type to extract the selectors from the provided ResultType, so that we know if we have a BaseStoreSelector or an EntityStoreSelector, this way
+// we get correct typing in our services
+type StoreSelectors<ResultType extends StoreFlowAssets> = {
+	[Key in keyof ResultType]: ResultType[Key]['selectors'];
+};
+
+// Iben: Type to extract the actions from the provided ResultType, so that we know if we have a BaseStoreAction or an EntityStoreAction, this way
+// we get correct typing in our services
+type StoreActions<ResultType extends StoreFlowAssets> = {
+	[Key in keyof ResultType]: ResultType[Key]['actions'];
+};
+
+/**
+ * The typing of the store of all sub slices
+ *
+ * @template ResultType - The typing we wish to see for our actions, reducers and selectors
+ */
+export interface NgxStore<ResultType extends StoreFlowAssets> {
+	selectors: StoreSelectors<ResultType>;
+	actions: StoreActions<ResultType>;
+	reducers: ActionReducer<any, Action>;
+}

--- a/projects/store/src/lib/store/utils/store-generator.util/store-generator.util.ts
+++ b/projects/store/src/lib/store/utils/store-generator.util/store-generator.util.ts
@@ -1,42 +1,5 @@
-import { Action, ActionReducer, combineReducers } from '@ngrx/store';
-
-import { BaseStoreAssets, EntityStoreAssets } from '../../interfaces';
-
-/**
- * These objects will be used as a blueprint for our store slices
- *
- * @template SliceKey - The keys of our store
- */
-export interface StoreAssetsOptions<SliceKey extends string | number | symbol> {
-	subSlice: SliceKey;
-	generator: (slice: string) => EntityStoreAssets<any> | BaseStoreAssets<any>;
-}
-
-// Iben: The base type for our flow assets which we'll pass to the create generator
-type StoreFlowAssets = Record<string, EntityStoreAssets<any> | BaseStoreAssets<any>>;
-
-// Iben: Type to extract the selectors from the provided ResultType, so that we know if we have a BaseStoreSelector or an EntityStoreSelector, this way
-// we get correct typing in our services
-type StoreSelectors<ResultType extends StoreFlowAssets> = {
-	[Key in keyof ResultType]: ResultType[Key]['selectors'];
-};
-
-// Iben: Type to extract the actions from the provided ResultType, so that we know if we have a BaseStoreAction or an EntityStoreAction, this way
-// we get correct typing in our services
-type StoreActions<ResultType extends StoreFlowAssets> = {
-	[Key in keyof ResultType]: ResultType[Key]['actions'];
-};
-
-/**
- * The typing of the store of all sub slices
- *
- * @template ResultType - The typing we wish to see for our actions, reducers and selectors
- */
-export interface NgxStore<ResultType extends StoreFlowAssets> {
-	selectors: StoreSelectors<ResultType>;
-	actions: StoreActions<ResultType>;
-	reducers: ActionReducer<any, Action>;
-}
+import { combineReducers } from '@ngrx/store';
+import { NgxStore, StoreAssetsOptions, StoreFlowAssets } from '../../interfaces';
 
 /**
  * Generates selectors,actions and reducers for a store
@@ -54,7 +17,9 @@ export const createStoreAssets = <ResultType extends StoreFlowAssets>(
 	const storeAssets: ResultType = [...options].reduce((result, current): ResultType => {
 		return {
 			...result,
-			[current.subSlice]: current.generator(`${slice}.${current.subSlice.toString()}`),
+			[current.subSlice]: current.selectId
+				? current.generator(`${slice}.${current.subSlice.toString()}`, current.selectId)
+				: current.generator(`${slice}.${current.subSlice.toString()}`),
 		};
 	}, {} as ResultType);
 

--- a/projects/store/src/public-api.ts
+++ b/projects/store/src/public-api.ts
@@ -2,7 +2,15 @@
  * Public API Surface of store
  */
 export { StoreService } from './lib/store/abstracts';
-export { BaseStoreAssets, EntityStoreAssets } from './lib/store/interfaces';
+export {
+	BaseStoreAssets,
+	EntityStoreAssets,
+	NgxStore,
+	BaseStoreActions,
+	BaseStoreSelectors,
+	EntityStoreActions,
+	EntityStoreSelectors,
+} from './lib/store/interfaces';
 export {
 	createStoreAssets,
 	dispatchDataToStore,


### PR DESCRIPTION
The current implementation allowed for a selectId function, but did not allow us to pass it onto the generator. This PR fixes this issue and also exports a few needed interfaces.