### PR TITLE
feat(utils): added withRouterLinksPipe to allow for in-text router-link conversion

### DIFF
--- a/projects/i18n/README.md
+++ b/projects/i18n/README.md
@@ -93,6 +93,7 @@ Which we'll then provide to the `NgxI18nModule` in our feature module
  export class FeatureModule{}
 ```
 With this setup, the translations will be loaded only when navigating to the FeatureModule.
+
 ## build information
 This project has been build with:
 - Angular CLI : `16.1.4`

--- a/projects/utils/README.md
+++ b/projects/utils/README.md
@@ -88,6 +88,12 @@ The TruncateTextPipe will truncate a given text to a given number of characters 
 
 [Full documentation.](src/lib/pipes/truncate-text/truncate-text.pipe.md)
 
+### WithRouterLinksPipe
+
+The withRouterLinks pipe will provide a way to transform a string that contains one or more parts that need a routerLink by taking advantage of Angular web components.
+
+[Full documentation.](src/lib/pipes/with-router-links/with-router-links.md)
+
 ## Services
 ### 1. Window service
 This service uses the `DOCUMENT` injection-token to provide several methods to access both document and window and related information.

--- a/projects/utils/package-lock.json
+++ b/projects/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiohyperdrive/ngx-utils",
-  "version": "16.2.0",
+  "version": "16.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiohyperdrive/ngx-utils",
-      "version": "16.2.0",
+      "version": "16.2.1",
       "peerDependencies": {
         "@angular/common": "^16.1.5",
         "@angular/core": "^16.1.5"

--- a/projects/utils/package-lock.json
+++ b/projects/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiohyperdrive/ngx-utils",
-  "version": "16.1.1",
+  "version": "16.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiohyperdrive/ngx-utils",
-      "version": "16.1.1",
+      "version": "16.2.0",
       "peerDependencies": {
         "@angular/common": "^16.1.5",
         "@angular/core": "^16.1.5"

--- a/projects/utils/package.json
+++ b/projects/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@studiohyperdrive/ngx-utils",
   "homepage": "https://github.com/studiohyperdrive/ngx-tools/blob/master/projects/utils/README.md",
-  "version": "16.2.0",
+  "version": "16.2.1",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^16.1.5",

--- a/projects/utils/package.json
+++ b/projects/utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@studiohyperdrive/ngx-utils",
+  "homepage": "https://github.com/studiohyperdrive/ngx-tools/blob/master/projects/utils/README.md",
   "version": "16.1.1",
   "license": "MIT",
   "peerDependencies": {

--- a/projects/utils/package.json
+++ b/projects/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@studiohyperdrive/ngx-utils",
   "homepage": "https://github.com/studiohyperdrive/ngx-tools/blob/master/projects/utils/README.md",
-  "version": "16.1.1",
+  "version": "16.2.0",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^16.1.5",

--- a/projects/utils/src/lib/pipes/index.ts
+++ b/projects/utils/src/lib/pipes/index.ts
@@ -10,6 +10,7 @@ import { SafeHtmlPipe } from './safe-html/safe-html.pipe';
 import { StripHtmlPipe } from './strip-html/strip-html.pipe';
 import { TransformPipe } from './transform/transform.pipe';
 import { TruncateTextPipe } from './truncate-text/truncate-text.pipe';
+import { WithRouterLinkPipe } from './with-router-links/with-router-links.pipe';
 
 export const Pipes = [
 	IbanPipe,
@@ -24,6 +25,7 @@ export const Pipes = [
 	TransformPipe,
 	JoinPipe,
 	HasObserversPipe,
+	WithRouterLinkPipe,
 ];
 
 export { BtwPipe } from './btw/btw.pipe';

--- a/projects/utils/src/lib/pipes/index.ts
+++ b/projects/utils/src/lib/pipes/index.ts
@@ -40,3 +40,4 @@ export { SafeHtmlPipe } from './safe-html/safe-html.pipe';
 export { StripHtmlPipe } from './strip-html/strip-html.pipe';
 export { TransformPipe } from './transform/transform.pipe';
 export { TruncateTextPipe } from './truncate-text/truncate-text.pipe';
+export { WithRouterLinkPipe } from './with-router-links/with-router-links.pipe';

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.config.ts
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.config.ts
@@ -1,0 +1,6 @@
+import { InjectionToken } from '@angular/core';
+import { WithRouterLinksConfig } from './with-router-links.types';
+
+export const WITH_ROUTER_LINKS_CONFIG = new InjectionToken<WithRouterLinksConfig>(
+	'withRouterLinksConfig'
+);

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.md
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.md
@@ -55,11 +55,11 @@ Lastly set up the global config in the appropriate module:
             provide: WITH_ROUTER_LINKS_CONFIG,
             useValue: {
                 // The selector of the component
-                elSelector: 'link-el',
+                replaceElementSelector: 'link-el',
                 // The input property of the component
-                linkAttr: 'to',
+                linkAttributeName: 'to',
                 // The data attribute used in the string to mark the anchor that needs to be targetted
-                dataLinkIdAttr: 'data-link-id',
+                dataLinkIdAttributeName: 'data-link-id',
             } as WithRouterLinksConfig
         }
     ]
@@ -82,8 +82,8 @@ Within the template you can now provide the string and transform it like this:
 
 ```angular2html
 <p [innerHTML]="string | withRouterLinks : [{
-    select: 'someUniqueId',
-    linkTo: ['somewhere', 'in', 'the', 'app']
+    dataLinkId: 'someUniqueId',
+    link: ['somewhere', 'in', 'the', 'app']
 }]"></p>
 ```
 
@@ -92,12 +92,13 @@ The linkTo will transform your array to a string. It also expects plain string p
 #### Deviating from the global settings
 
 If you'd want to deviate from the global settings and use a different component for a specific string, you can provide additional config like this:
+
 ```angular2html
 <p [innerHTML]="string | withRouterLinks : [{
-    select: 'someUniqueId',
-    linkTo: ['somewhere', 'in', 'the', 'app'],
-    elSelector: 'my-other-el',
-	toAttr: 'input-prop',
+    dataLinkId: 'someUniqueId',
+    link: ['somewhere', 'in', 'the', 'app'],
+    replaceElementSelector: 'my-other-el',
+	toAttribute: 'input-prop',
 }]"></p>
 ```
 

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.md
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.md
@@ -1,0 +1,104 @@
+# `withRouterLinks`
+
+The `withRouterLinks` pipe will provide a way to transform a string that contains one or more parts that need a routerLink by taking advantage of Angular web components.
+
+This can be useful in combination with translation strings that require in-app links or WYSIWYG content from an external source.
+
+## How to use
+
+### Set up
+
+The pipe requires a couple of things to be provided before it can be used.
+
+First, create a component that wraps around your anchor with router-link:
+```typescript
+@Component({
+    selector: 'link',
+    template: '<a [routerLink]="to"></a>',
+})
+export class LinkComponent {
+    // Keep in mind that Angular's innerHTML & outerHTML will convert attributes to lower casing.
+    // This input property will need to be lowercased to make this work.
+    @Input() public to: string;
+}
+```
+
+Then register it as a web component in your `app.component.ts`:
+
+```typescript
+@Component({
+    //...
+})
+export class AppComponent {
+    constructor(
+        // ...
+        private readonly windowService: WindowService,
+        private readonly injector: Injector
+    ) {
+        // Note that we are using our WindowService (ngx-utils) to avoid SSR issues.
+        if (this.windowService.isBrowser) {
+            const linkComponent = createCustomElement(LinkComponent, {injector: this.injector});
+
+            customElements.define('link-el', linkComponent);
+        }
+    }
+}
+```
+
+Lastly set up the global config in the appropriate module:
+```typescript
+@NgModule({
+    // ...
+    providers: [
+        //...
+        {
+            provide: WITH_ROUTER_LINKS_CONFIG,
+            useValue: {
+                // The selector of the component
+                elSelector: 'link-el',
+                // The input property of the component
+                linkAttr: 'to',
+                // The data attribute used in the string to mark the anchor that needs to be targetted
+                dataLinkIdAttr: 'data-link-id',
+            } as WithRouterLinksConfig
+        }
+    ]
+})
+export class SomeModule {} 
+```
+
+### Using the pipe
+
+When the web component is set up, you can start using the pipe.
+
+First set up anchors in your input string:
+```text
+"This is a text with a <a data-link-id='someUniqueId'>link</a>."
+```
+
+The `someUniqueId` will be used by the pipe to find and replace your link element so make sure that each anchor within your translation has a unique identifier.
+
+Within the template you can now provide the string and transform it like this:
+
+```angular2html
+<p [innerHTML]="string | withRouterLinks : [{
+    select: 'someUniqueId',
+    linkTo: ['somewhere', 'in', 'the', 'app']
+}]"></p>
+```
+
+The linkTo will transform your array to a string. It also expects plain string paths instead of arrays.
+
+#### Deviating from the global settings
+
+If you'd want to deviate from the global settings and use a different component for a specific string, you can provide additional config like this:
+```angular2html
+<p [innerHTML]="string | withRouterLinks : [{
+    select: 'someUniqueId',
+    linkTo: ['somewhere', 'in', 'the', 'app'],
+    elSelector: 'my-other-el',
+	toAttr: 'input-prop',
+}]"></p>
+```
+
+Do note, again, that Angular will always lowercase attributes on HTML provided through the innerHTML & outerHTML directives.

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.pipe.spec.ts
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.pipe.spec.ts
@@ -4,9 +4,9 @@ import { WithRouterLinksConfig } from './with-router-links.types';
 
 describe('WithRouterLinkPipe', () => {
 	const config: WithRouterLinksConfig = {
-		elSelector: 'my-link',
-		linkAttr: 'to',
-		dataLinkIdAttr: 'data-link-id',
+		replaceElementSelector: 'my-link',
+		linkAttributeName: 'to',
+		dataLinkIdAttributeName: 'data-link-id',
 	};
 	const sanitizer: DomSanitizer = {
 		bypassSecurityTrustHtml: jasmine.createSpy().and.callFake((value) => value),
@@ -18,14 +18,14 @@ describe('WithRouterLinkPipe', () => {
 			'This is a text with a <a data-link-id="someUniqueId">link</a>.',
 			[
 				{
-					select: 'someUniqueId',
-					linkTo: ['path', 'in', 'app'],
+					dataLinkId: 'someUniqueId',
+					link: ['path', 'in', 'app'],
 				},
 			]
 		);
 
 		expect(result).toBe(
-			`<head></head><body>This is a text with a <my-link to="/path/in/app">link</my-link>.</body>`
+			`<head></head><body>This is a text with a <my-link to="path/in/app">link</my-link>.</body>`
 		);
 	});
 
@@ -34,8 +34,8 @@ describe('WithRouterLinkPipe', () => {
 			'This is a text with a <a data-link-id="someUniqueId">link</a>.',
 			[
 				{
-					select: 'someUniqueId',
-					linkTo: '/path/in/app',
+					dataLinkId: 'someUniqueId',
+					link: '/path/in/app',
 				},
 			]
 		);
@@ -50,10 +50,10 @@ describe('WithRouterLinkPipe', () => {
 			'This is a text with a <a data-link-id="someUniqueId">link</a>.',
 			[
 				{
-					select: 'someUniqueId',
-					linkTo: '/path/in/app',
-					elSelector: 'other-el',
-					toAttr: 'other-prop',
+					dataLinkId: 'someUniqueId',
+					link: '/path/in/app',
+					replaceElementSelector: 'other-el',
+					toAttribute: 'other-prop',
 				},
 			]
 		);
@@ -63,29 +63,52 @@ describe('WithRouterLinkPipe', () => {
 		);
 	});
 
-	it('should conver multiple links', () => {
+	it('should convert multiple links', () => {
 		const result = pipe.transform(
 			'This is a text with multiple links: <a data-link-id="someUniqueId1">link 1</a>, <a data-link-id="someUniqueId2">link 2</a>, <a data-link-id="someUniqueId3">link 3</a>.',
 			[
 				{
-					select: 'someUniqueId1',
-					linkTo: ['path', 'in', 'app'],
+					dataLinkId: 'someUniqueId1',
+					link: ['path', 'in', 'app'],
 				},
 				{
-					select: 'someUniqueId2',
-					linkTo: '/path/in/app',
+					dataLinkId: 'someUniqueId2',
+					link: '/path/in/app',
 				},
 				{
-					select: 'someUniqueId3',
-					linkTo: ['path', 'in', 'app'],
-					elSelector: 'other-el',
-					toAttr: 'other-prop',
+					dataLinkId: 'someUniqueId3',
+					link: ['path', 'in', 'app'],
+					replaceElementSelector: 'other-el',
+					toAttribute: 'other-prop',
 				},
 			]
 		);
 
 		expect(result).toBe(
-			`<head></head><body>This is a text with multiple links: <my-link to="/path/in/app">link 1</my-link>, <my-link to="/path/in/app">link 2</my-link>, <other-el other-prop="/path/in/app">link 3</other-el>.</body>`
+			`<head></head><body>This is a text with multiple links: <my-link to="path/in/app">link 1</my-link>, <my-link to="/path/in/app">link 2</my-link>, <other-el other-prop="path/in/app">link 3</other-el>.</body>`
+		);
+	});
+
+	it('should return the orginal value if it is not a string', () => {
+		expect(pipe.transform(null)).toBe(null);
+		expect(pipe.transform(undefined)).toBe(undefined);
+		expect(pipe.transform(1 as any)).toBe(1);
+		expect(pipe.transform(true as any)).toBe(true);
+	});
+
+	it('should exclude anchors without a matching reference', () => {
+		const result = pipe.transform(
+			'This is a text with multiple links: <a data-link-id="someUniqueId1">link 1</a>, <a href="https://studiohyperdrive.be">link 2</a>, <a data-link-id="someUniqueId3">link 3</a>.',
+			[
+				{
+					dataLinkId: 'someUniqueId1',
+					link: ['path', 'in', 'app'],
+				},
+			]
+		);
+
+		expect(result).toBe(
+			`<head></head><body>This is a text with multiple links: <my-link to="path/in/app">link 1</my-link>, <a href="https://studiohyperdrive.be">link 2</a>, <a data-link-id="someUniqueId3">link 3</a>.</body>`
 		);
 	});
 });

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.pipe.spec.ts
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.pipe.spec.ts
@@ -1,0 +1,91 @@
+import { DomSanitizer } from '@angular/platform-browser';
+import { WithRouterLinkPipe } from './with-router-links.pipe';
+import { WithRouterLinksConfig } from './with-router-links.types';
+
+describe('WithRouterLinkPipe', () => {
+	const config: WithRouterLinksConfig = {
+		elSelector: 'my-link',
+		linkAttr: 'to',
+		dataLinkIdAttr: 'data-link-id',
+	};
+	const sanitizer: DomSanitizer = {
+		bypassSecurityTrustHtml: jasmine.createSpy().and.callFake((value) => value),
+	} as any as DomSanitizer;
+	const pipe: WithRouterLinkPipe = new WithRouterLinkPipe(config, sanitizer);
+
+	it('should convert a single link with a an array link & global config', () => {
+		const result = pipe.transform(
+			'This is a text with a <a data-link-id="someUniqueId">link</a>.',
+			[
+				{
+					select: 'someUniqueId',
+					linkTo: ['path', 'in', 'app'],
+				},
+			]
+		);
+
+		expect(result).toBe(
+			`<head></head><body>This is a text with a <my-link to="/path/in/app">link</my-link>.</body>`
+		);
+	});
+
+	it('should convert a single link with a an string link & global config', () => {
+		const result = pipe.transform(
+			'This is a text with a <a data-link-id="someUniqueId">link</a>.',
+			[
+				{
+					select: 'someUniqueId',
+					linkTo: '/path/in/app',
+				},
+			]
+		);
+
+		expect(result).toBe(
+			`<head></head><body>This is a text with a <my-link to="/path/in/app">link</my-link>.</body>`
+		);
+	});
+
+	it('should convert a single link with case-specific config', () => {
+		const result = pipe.transform(
+			'This is a text with a <a data-link-id="someUniqueId">link</a>.',
+			[
+				{
+					select: 'someUniqueId',
+					linkTo: '/path/in/app',
+					elSelector: 'other-el',
+					toAttr: 'other-prop',
+				},
+			]
+		);
+
+		expect(result).toBe(
+			`<head></head><body>This is a text with a <other-el other-prop="/path/in/app">link</other-el>.</body>`
+		);
+	});
+
+	it('should conver multiple links', () => {
+		const result = pipe.transform(
+			'This is a text with multiple links: <a data-link-id="someUniqueId1">link 1</a>, <a data-link-id="someUniqueId2">link 2</a>, <a data-link-id="someUniqueId3">link 3</a>.',
+			[
+				{
+					select: 'someUniqueId1',
+					linkTo: ['path', 'in', 'app'],
+				},
+				{
+					select: 'someUniqueId2',
+					linkTo: '/path/in/app',
+				},
+				{
+					select: 'someUniqueId3',
+					linkTo: ['path', 'in', 'app'],
+					elSelector: 'other-el',
+					toAttr: 'other-prop',
+				},
+			]
+		);
+
+		expect(result).toBe(
+			`<head></head><body>This is a text with multiple links: <my-link to="/path/in/app">link 1</my-link>, <my-link to="/path/in/app">link 2</my-link>, <other-el other-prop="/path/in/app">link 3</other-el>.</body>`
+		);
+	});
+});

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.pipe.ts
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.pipe.ts
@@ -1,0 +1,49 @@
+import { Inject, Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { LinkReference, WithRouterLinksConfig } from './with-router-links.types';
+import { WITH_ROUTER_LINKS_CONFIG } from './with-router-links.config';
+
+/**
+ * An additional pipe to convert anchors to router-links
+ */
+@Pipe({
+	name: 'withRouterLinks',
+})
+export class WithRouterLinkPipe implements PipeTransform {
+	constructor(
+		@Inject(WITH_ROUTER_LINKS_CONFIG) private readonly config: WithRouterLinksConfig,
+		private readonly sanitizer: DomSanitizer
+	) {}
+
+	public transform(value: string, linkReferences: LinkReference[] = []): any {
+		if (typeof value !== 'string') {
+			return value;
+		}
+
+		const parser: DOMParser = new DOMParser();
+		const body: Document = parser.parseFromString(value, 'text/html');
+
+		linkReferences.forEach(({ select, linkTo, elSelector, toAttr }: LinkReference) => {
+			const selector: string = `a[${this.config.dataLinkIdAttr}="${select}"]`;
+			const placeholderLink: HTMLElement = body.querySelector(selector);
+
+			if (!placeholderLink) {
+				return;
+			}
+
+			const parsedLink: HTMLElement = body.createElement(
+				elSelector || this.config.elSelector
+			);
+			const routerLinkValue: string = Array.isArray(linkTo)
+				? ['', ...linkTo].join('/')
+				: linkTo;
+
+			parsedLink.setAttribute(toAttr || this.config.linkAttr, routerLinkValue);
+			parsedLink.innerText = placeholderLink.innerText;
+
+			placeholderLink.replaceWith(parsedLink);
+		});
+
+		return this.sanitizer.bypassSecurityTrustHtml(body.documentElement.innerHTML);
+	}
+}

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.pipe.ts
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.pipe.ts
@@ -15,35 +15,70 @@ export class WithRouterLinkPipe implements PipeTransform {
 		private readonly sanitizer: DomSanitizer
 	) {}
 
+	/**
+	 * transform
+	 *
+	 * The transform method loop through the linkReferences and find/replace matching
+	 * references within the given value (string) with the provided web component (global/local config).
+	 *
+	 * @param value
+	 * @param linkReferences
+	 */
 	public transform(value: string, linkReferences: LinkReference[] = []): any {
+		// Denis: Check if the provided value is a string,
+		// if not, the DOMParser would fail, so return the value as given.
 		if (typeof value !== 'string') {
 			return value;
 		}
 
+		// Denis: set up a new instance of the DOMParser and parse the value as text/html.
+		// This will return a Document which we can work with to find/replace elements.
 		const parser: DOMParser = new DOMParser();
 		const body: Document = parser.parseFromString(value, 'text/html');
 
-		linkReferences.forEach(({ select, linkTo, elSelector, toAttr }: LinkReference) => {
-			const selector: string = `a[${this.config.dataLinkIdAttr}="${select}"]`;
-			const placeholderLink: HTMLElement = body.querySelector(selector);
+		// Denis: loop over each reference within the linkReferences.
+		// The argument defaults to an empty array, if no linkReferences are provided,
+		// it will loop over an empty array.
+		linkReferences.forEach(
+			({ dataLinkId, link, replaceElementSelector, toAttribute }: LinkReference) => {
+				// Denis: construct the selector string
+				const selector: string = `a[${this.config.dataLinkIdAttributeName}="${dataLinkId}"]`;
+				// Denis: select the palceholder element within the parsed Document.
+				const placeholderLink: HTMLElement = body.querySelector(selector);
 
-			if (!placeholderLink) {
-				return;
+				// Denis: if no placeholder is found, early return.
+				if (!placeholderLink) {
+					return;
+				}
+
+				// Denis: create a new element within the Document based on the provided selector.
+				// The selector can be any native or custom web component (not an Angular component).
+				// Keep in mind that the element will need to have a lowercase input prop for the reference.
+				// We will attempt to create the element with the replaceElementSelector (local)
+				// and fall back to the config.replaceElementSelector (global).
+				const parsedLink: HTMLElement = body.createElement(
+					replaceElementSelector || this.config.replaceElementSelector
+				);
+				// Denis: because setAttribute expects a string value,
+				// check if the provided routerLinkValue is an Array. If so, join it.
+				const routerLinkValue: string = Array.isArray(link) ? link.join('/') : link;
+
+				// Denis: set the link attribute of the component.
+				// We will attempt to set the attribute with the linkAttributeName (local)
+				// and fall back to the config.linkAttributeName (global).
+				parsedLink.setAttribute(
+					toAttribute || this.config.linkAttributeName,
+					routerLinkValue
+				);
+				// Denis: copy the innerText of the placeholder element to the new element.
+				parsedLink.innerText = placeholderLink.innerText;
+
+				// Denis: replace the placeholder with the new element within the Document.
+				placeholderLink.replaceWith(parsedLink);
 			}
+		);
 
-			const parsedLink: HTMLElement = body.createElement(
-				elSelector || this.config.elSelector
-			);
-			const routerLinkValue: string = Array.isArray(linkTo)
-				? ['', ...linkTo].join('/')
-				: linkTo;
-
-			parsedLink.setAttribute(toAttr || this.config.linkAttr, routerLinkValue);
-			parsedLink.innerText = placeholderLink.innerText;
-
-			placeholderLink.replaceWith(parsedLink);
-		});
-
+		// Denis: sanitize the document and mark it as trusted HTML before returning it to the template.
 		return this.sanitizer.bypassSecurityTrustHtml(body.documentElement.innerHTML);
 	}
 }

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.types.ts
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.types.ts
@@ -1,12 +1,12 @@
 export interface WithRouterLinksConfig {
-	elSelector: string;
-	linkAttr: string;
-	dataLinkIdAttr: string;
+	replaceElementSelector: string;
+	linkAttributeName: string;
+	dataLinkIdAttributeName: string;
 }
 
 export interface LinkReference {
-	select: string;
-	linkTo: string | string[];
-	elSelector?: string;
-	toAttr?: string;
+	dataLinkId: string;
+	link: string | string[];
+	replaceElementSelector?: string;
+	toAttribute?: string;
 }

--- a/projects/utils/src/lib/pipes/with-router-links/with-router-links.types.ts
+++ b/projects/utils/src/lib/pipes/with-router-links/with-router-links.types.ts
@@ -1,0 +1,12 @@
+export interface WithRouterLinksConfig {
+	elSelector: string;
+	linkAttr: string;
+	dataLinkIdAttr: string;
+}
+
+export interface LinkReference {
+	select: string;
+	linkTo: string | string[];
+	elSelector?: string;
+	toAttr?: string;
+}

--- a/projects/utils/src/lib/utils.const.ts
+++ b/projects/utils/src/lib/utils.const.ts
@@ -1,0 +1,1 @@
+export { WITH_ROUTER_LINKS_CONFIG } from './pipes/with-router-links/with-router-links.config';

--- a/projects/utils/src/lib/utils.types.ts
+++ b/projects/utils/src/lib/utils.types.ts
@@ -1,0 +1,4 @@
+export {
+	LinkReference,
+	WithRouterLinksConfig,
+} from './pipes/with-router-links/with-router-links.types';


### PR DESCRIPTION
This PR adds a pipe that is able to find and replace in-text anchors with a web component that wraps around a router-link.

For more info check the README.