### PR TITLE
fix(ngx-table): Don't show open row state if no detail row is provided

### DIFF
--- a/projects/table-test/src/app/app.component.html
+++ b/projects/table-test/src/app/app.component.html
@@ -22,7 +22,7 @@
 	<ng-template #radioTmpl let-control let-row="row" let-index="index">
 		<input type="radio" name="control" [id]="index" [formControl]="control" [value]="row.id" />
 	</ng-template>
-	<ng-template #detailRowTmpl let-row>
+	<ng-template *ngIf="showDetail" #detailRowTmpl let-row>
 		{{row | json}}
 	</ng-template>
 </ngx-table>
@@ -32,3 +32,4 @@
 </p>
 
 <button (click)="setFormValue()">Set form value</button>
+<button (click)="toggleDetailView()">Toggle detail row</button>

--- a/projects/table-test/src/app/app.component.ts
+++ b/projects/table-test/src/app/app.component.ts
@@ -30,9 +30,15 @@ export class AppComponent {
 
 	public readonly columns = ['firstName', 'name', 'active'];
 
+	public showDetail = true;
+
 	public form = new FormControl();
 
 	public setFormValue() {
 		this.form.patchValue('id2');
+	}
+
+	public toggleDetailView() {
+		this.showDetail = !this.showDetail;
 	}
 }

--- a/projects/table-test/src/app/app.module.ts
+++ b/projects/table-test/src/app/app.module.ts
@@ -11,7 +11,7 @@ import { NgxTableConfigToken, NgxTableModule } from 'table';
 	providers: [
 		{
 			provide: NgxTableConfigToken,
-			useValue: { showDetailRow: 'on-single-item' },
+			useValue: { showDetailRow: 'on-single-item', showOpenRowState: true },
 		},
 	],
 	bootstrap: [AppComponent],

--- a/projects/table/package.json
+++ b/projects/table/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@studiohyperdrive/ngx-table",
-  "version": "16.1.1",
+  "homepage": "https://github.com/studiohyperdrive/ngx-tools/blob/master/projects/table/README.md",
+  "version": "16.1.2",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^16.1.0",

--- a/projects/table/src/lib/table/ngx-table.component.ts
+++ b/projects/table/src/lib/table/ngx-table.component.ts
@@ -418,7 +418,7 @@ export class NgxTableComponent
 			...(this.selectable ? ['ngxTableSelectColumn'] : []),
 			...(this.columns || []),
 			...(this.actions || []),
-			...(this.showOpenRowState ? ['ngxOpenRowStateColumn'] : []),
+			...(this.showOpenRowState && this.detailRowTemplate ? ['ngxOpenRowStateColumn'] : []),
 		];
 
 		// Iben: Set the actual table columns
@@ -428,7 +428,8 @@ export class NgxTableComponent
 	// Lifecycle methods
 	// ==============================
 	public ngAfterContentChecked(): void {
-		// Iben: Run with content check so that we can dynamically add templates
+		// Iben: Run with content check so that we can dynamically add templates/columns
+		this.handleRowColumns();
 		this.handleTableCellTemplates();
 	}
 


### PR DESCRIPTION
The open row state was shown even when no detail row was provided. This should fix this issue.