### PR TITLE
bugfix(ngx-utils): The stripHtml pipe now has an optional 'replaceWith' argument

### DIFF
--- a/projects/utils/package-lock.json
+++ b/projects/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiohyperdrive/ngx-utils",
-  "version": "16.3.0",
+  "version": "17.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiohyperdrive/ngx-utils",
-      "version": "16.3.0",
+      "version": "17.2.0",
       "peerDependencies": {
         "@angular/common": "^16.1.5",
         "@angular/core": "^16.1.5"

--- a/projects/utils/package.json
+++ b/projects/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@studiohyperdrive/ngx-utils",
 	"homepage": "https://github.com/studiohyperdrive/ngx-tools/blob/master/projects/utils/README.md",
-	"version": "17.1.0",
+	"version": "17.2.0",
 	"license": "MIT",
 	"peerDependencies": {
 		"@angular/common": "^17.0.4",

--- a/projects/utils/src/lib/pipes/strip-html/strip-html.pipe.spec.ts
+++ b/projects/utils/src/lib/pipes/strip-html/strip-html.pipe.spec.ts
@@ -4,6 +4,14 @@ describe('StripHtmlPipe', () => {
 	const pipe = new StripHtmlPipe();
 
 	it('strips all html from a string', () => {
-		expect(pipe.transform('<p>Test</p>')).toBe('Test');
+		expect(pipe.transform('This is a <p>test</p> to see if the pipe works.')).toBe(
+			'This is a test to see if the pipe works.'
+		);
+	});
+
+	it('strips all html from a string with a request space', () => {
+		expect(pipe.transform('This is a <p>test</p> to see if the pipe works.', ' ')).toBe(
+			'This is a  test  to see if the pipe works.'
+		);
 	});
 });

--- a/projects/utils/src/lib/pipes/strip-html/strip-html.pipe.ts
+++ b/projects/utils/src/lib/pipes/strip-html/strip-html.pipe.ts
@@ -4,12 +4,12 @@ import { Pipe, PipeTransform } from '@angular/core';
 	name: 'stripHtml',
 })
 export class StripHtmlPipe implements PipeTransform {
-	public transform(value: string): string {
+	public transform(value: string, replaceWith: string = ''): string {
 		return value
 			? String(value)
-					.replace(/<[^>]+>/gm, '')
-					.replace('&nbsp;', '')
-					.replace(/(\r\n|\n|\r)/gm, '')
+					.replace(/<[^>]+>/gm, replaceWith)
+					.replace('&nbsp;', replaceWith)
+					.replace(/(\r\n|\n|\r)/gm, replaceWith)
 			: '';
 	}
 }


### PR DESCRIPTION
A change to the stripHTML pipe that I've tried out a while ago but never actually needed (scope change).

Since I've built it, might be good to actually release it so that others can use it.