### PR TITLE
bugfix(ngx-forms): The email validator is now case insensitive and allows for longer TLDs

### DIFF
--- a/projects/forms/package-lock.json
+++ b/projects/forms/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiohyperdrive/ngx-forms",
-  "version": "16.0.1",
+  "version": "17.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiohyperdrive/ngx-forms",
-      "version": "16.0.1",
+      "version": "17.0.4",
       "dependencies": {
         "obj-clean": "^3.0.1",
         "tslib": "^2.5.0"

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@studiohyperdrive/ngx-forms",
   "homepage": "https://github.com/studiohyperdrive/ngx-tools/blob/master/projects/forms/README.md",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^17.0.4",

--- a/projects/forms/src/lib/validators/email/extended-email.validator.ts
+++ b/projects/forms/src/lib/validators/email/extended-email.validator.ts
@@ -8,7 +8,7 @@ export const extendedEmailValidator = (control: AbstractControl): ValidationErro
 	}
 
 	// Validates more strictly than the default email validator. Requires a period in the tld part.
-	return /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$/.test(control.value)
+	return /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]+$/gi.test(control.value)
 		? null
 		: { extendedEmail: true };
 };


### PR DESCRIPTION
The email validator regex was too restrictive which caused it to fail on:
- TLDs that were longer than four characters (eg. `.design`).
- Cased emailaddresses, which is common in office365 managed organisations