### PR TITLE
fix(ngx-layout): Fix styling issues with equal sizing

### DIFF
--- a/projects/layout-test/src/app/app.component.html
+++ b/projects/layout-test/src/app/app.component.html
@@ -14,25 +14,31 @@
 <hr />
 
 <ngx-configurable-layout
-	[allowDragAndDrop]="true"
+	itemSize="equal"
 	[keys]="[
 		['1', '2'],
 		['a', 'b']
 	]"
+	rowGap="10px"
+	columnGap="10px"
 >
 	<ngx-configurable-layout-item key="a">
-		<p class="layout-items large">Form key a</p>
+		<div class="layout-items large">Form key a</div>
 	</ngx-configurable-layout-item>
 
 	<ngx-configurable-layout-item key="b">
-		<p class="layout-items">Form key b</p>
+		<div class="layout-items">Form key b</div>
 	</ngx-configurable-layout-item>
 
 	<ngx-configurable-layout-item key="1">
-		<p class="layout-items">Input key 1</p>
+		<div class="layout-items">
+			Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatum veritatis laudantium
+			ut officia omnis, impedit eligendi, ea molestiae magnam odit et animi quod illo eius.
+			Fuga nihil adipisci molestiae magni?
+		</div>
 	</ngx-configurable-layout-item>
 
 	<ngx-configurable-layout-item key="2">
-		<p class="layout-items">Input key 2</p>
+		<div class="layout-items">Input key 2</div>
 	</ngx-configurable-layout-item>
 </ngx-configurable-layout>

--- a/projects/layout-test/src/app/app.component.scss
+++ b/projects/layout-test/src/app/app.component.scss
@@ -1,11 +1,10 @@
 ngx-configurable-layout {
 	background-color: rgb(242, 242, 242);
-	gap: 1rem;
-	padding: 1rem;
 }
 
-p.layout-items {
+.layout-items {
+	height: 100%;
 	border: 1px solid black;
-	margin: 5px;
-	padding: 1rem;
+	padding: 10px;
+	box-sizing: border-box;
 }

--- a/projects/layout/README.md
+++ b/projects/layout/README.md
@@ -59,16 +59,22 @@ By using the option `fill`, which is the default option, the components will be 
 
 By using the option `fit-content`, the size of the components themselves will define how much space they take up.
 
-By using the option `equal`, all items in the entire grid will take up an equal amount of space.
+By using the option `equal`, all items in the entire grid will take up an equal amount of space. This also applies to the height of the elements, but this will require you to set the height of your items to `height:100%` for this to take effect.
 
-#### 2.1.3 Drag and drop
+#### 2.1.3 Gaps
 
-`ngx-layout` provides drag and drop through the Angular CDK implementation. By default, the drag and drop functionality is disabled, and can be enabled through `alowDragAndDrop`.
+In order to create spacing between items in the layout, `ngx-configurable-layout` provides two inputs, `columnGap` and `rowGap`.
+
+Both properties expect a CSS based amount (in px, rem, %, etc.) and are both optional. This is the preferred way of adding spacing between your items, as using margins can sometimes create unexpected results due to the CSS Grid based implementation. 
+
+#### 2.1.4 Drag and drop
+
+`ngx-configurable-layout` provides drag and drop through the Angular CDK implementation. By default, the drag and drop functionality is disabled, and can be enabled through `alowDragAndDrop`.
 
 By default, the package uses the demo styling provided by the Angular CDK team. This can be overwritten by custom styling, using the classes provided in the section `Styling`.
 
-#### 2.1.4 Styling
-By default, `ngx-layout` always provides minimal styling. Several classes are provided to further style the grid as needed.
+#### 2.1.5 Styling
+By default, `ngx-configurable-layout` always provides minimal styling. Several classes are provided to further style the grid as needed.
 
 | Class | |
 |--|--|

--- a/projects/layout/package.json
+++ b/projects/layout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@studiohyperdrive/ngx-layout",
-	"version": "17.0.0",
+	"version": "17.0.1",
 	"peerDependencies": {
 		"@angular/common": "^17.0.4",
 		"@angular/core": "^17.0.4",

--- a/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.html
+++ b/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.html
@@ -1,4 +1,9 @@
-<div cdkDropListGroup class="ngx-layout-grid">
+<div
+	cdkDropListGroup
+	class="ngx-layout-grid"
+	[class.ngx-layout-equal-size]="itemSize === 'equal'"
+	[style.row-gap]="rowGap"
+>
 	<ul
 		*ngFor="let row of form.value; let index = index"
 		cdkDropList
@@ -7,6 +12,7 @@
 		[cdkDropListDisabled]="!allowDragAndDrop && !form.disabled"
 		[id]="'ngx-layout-row-' + index"
 		[ngStyle]="form.value | ngxConfigurableLayoutItemSize : itemSize"
+		[style.column-gap]="columnGap"
 		(cdkDropListDropped)="drop($event)"
 	>
 		<ng-container *ngFor="let key of row">

--- a/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.scss
+++ b/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.scss
@@ -2,15 +2,28 @@
 	.ngx-layout-grid {
 		display: grid;
 		grid-auto-flow: row;
+
+		&.ngx-layout-equal-size {
+			grid-auto-rows: minmax(0, 1fr);
+		}
 	}
 
 	.ngx-layout-row {
 		display: grid;
 		grid-auto-flow: column;
+
+		height: 100%;
+		padding: unset;
+		margin: unset;
 	}
 
 	.ngx-layout-item {
+		padding: unset;
+		margin: unset;
+		min-height: max-content;
+
 		list-style-type: none;
+
 		&.cdk-drag {
 			&:not(.cdk-drag-disabled) {
 				cursor: move;

--- a/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.ts
+++ b/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.ts
@@ -112,7 +112,21 @@ export class NgxConfigurableLayoutComponent
 	@Input() public itemSize: NgxConfigurableLayoutItemSizeOption = 'fill';
 
 	/**
-	 * Whether drag and drop is enabled for the grid
+	 * An optional row gap we can provide to create a gap between the rows of the layout.
+	 *
+	 * This input requires an amount in px, rem, %, etc.
+	 */
+	@Input() public rowGap: string;
+
+	/**
+	 * An optional column gap we can provide to create a gap between the columns of the layout.
+	 *
+	 * This input requires an amount in px, rem, %, etc.
+	 */
+	@Input() public columnGap: string;
+
+	/**
+	 * Whether drag and drop is enabled for the layout.
 	 */
 	@Input() public allowDragAndDrop: boolean = false;
 


### PR DESCRIPTION
Before, the equal sizing did not allow items to be of equal size in height. This is unexpected behavior, as the grid suggests that all items will be of equal size.

Before:
![afbeelding](https://github.com/studiohyperdrive/ngx-tools/assets/10544531/590ce6d9-1091-4d65-983e-347887ad77b2)

After:
![afbeelding](https://github.com/studiohyperdrive/ngx-tools/assets/10544531/d1596060-d1fa-41fe-9450-09ade4dd6c48)


To allow for better styling, this PR also introduces the rowGap and the columnGap properties.