### PR TITLE
feat(ngx-layout): Make the ngx-configurable-layout editable by the end-user

### DIFF
--- a/projects/layout-test/src/app/app.component.html
+++ b/projects/layout-test/src/app/app.component.html
@@ -13,12 +13,56 @@
 
 <hr />
 
+<h1>Static</h1>
 <ngx-configurable-layout
+	layoutType="static"
 	itemSize="equal"
 	[keys]="[
 		['1', '2'],
 		['a', 'b']
 	]"
+	rowGap="10px"
+	columnGap="10px"
+>
+	<ngx-configurable-layout-item key="a">
+		<div class="layout-items large">Form key a</div>
+	</ngx-configurable-layout-item>
+
+	<ngx-configurable-layout-item key="b">
+		<div class="layout-items">Form key b</div>
+	</ngx-configurable-layout-item>
+
+	<ngx-configurable-layout-item key="1">
+		<div class="layout-items">
+			Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatum veritatis laudantium
+			ut officia omnis, impedit eligendi, ea molestiae magnam odit et animi quod illo eius.
+			Fuga nihil adipisci molestiae magni?
+		</div>
+	</ngx-configurable-layout-item>
+
+	<ngx-configurable-layout-item key="2">
+		<div class="layout-items">Input key 2</div>
+	</ngx-configurable-layout-item>
+</ngx-configurable-layout>
+
+<h1>Editable</h1>
+
+<label for="">
+	<input type="checkbox" [formControl]="isActive" />
+	Show inactive
+</label>
+
+<label for="">
+	<input type="checkbox" [formControl]="dragAndDrop" />
+	Drag and drop
+</label>
+
+<ngx-configurable-layout
+	layoutType="editable"
+	itemSize="equal"
+	[formControl]="control"
+	[showInactive]="isActive.value"
+	[allowDragAndDrop]="dragAndDrop.value"
 	rowGap="10px"
 	columnGap="10px"
 >

--- a/projects/layout-test/src/app/app.component.scss
+++ b/projects/layout-test/src/app/app.component.scss
@@ -5,6 +5,23 @@ ngx-configurable-layout {
 .layout-items {
 	height: 100%;
 	border: 1px solid black;
-	padding: 10px;
+	padding: 15px;
 	box-sizing: border-box;
+}
+
+label {
+	display: inline-block;
+	margin: 15px;
+	&:first-of-type {
+		margin-left: 0px;
+	}
+}
+
+::ng-deep {
+	.ngx-layout-item-inactive {
+		opacity: 0.5;
+		.layout-items {
+			border-style: dashed;
+		}
+	}
 }

--- a/projects/layout-test/src/app/app.component.ts
+++ b/projects/layout-test/src/app/app.component.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import {
 	NgxConfigurableLayoutComponent,
+	NgxConfigurableLayoutGrid,
 	NgxConfigurableLayoutItemComponent,
 } from 'projects/layout/src/public-api';
 
@@ -18,4 +19,17 @@ import {
 		ReactiveFormsModule,
 	],
 })
-export class AppComponent {}
+export class AppComponent {
+	public control: FormControl<NgxConfigurableLayoutGrid> = new FormControl([
+		[
+			{ key: '1', isActive: true },
+			{ key: '2', isActive: true },
+		],
+		[
+			{ key: 'a', isActive: true },
+			{ key: 'b', isActive: false },
+		],
+	]);
+	public isActive: FormControl<boolean> = new FormControl(false);
+	public dragAndDrop: FormControl<boolean> = new FormControl(false);
+}

--- a/projects/layout/README.md
+++ b/projects/layout/README.md
@@ -20,9 +20,17 @@ The `configurable layout` provides the ability to render components in a grid de
 
 By using content projection, we render our components inside of a `ngx-configurable-layout-item`. Each item requires a `key` as an input, which will be used to match the provided component with the two dimensional array we provide to the `ngx-configurable-layout` component.
 
-This means that the order of rendering is now no longer depended on how you provide the components in the template, but by the two dimensional array provided to the `ngx-configurable-layout` component. This significantly streamlines the process and allows you to easily refactor existing flows. 
+This means that the order of rendering is now no longer depended on how you provide the components in the template, but by the two dimensional array provided to the `ngx-configurable-layout` component. This significantly streamlines the process and allows you to easily refactor existing flows. In the chapters below we'll explain how to provide the two dimensional array to the component.
 
-To provide the array to the `ngx-configurable-layout` component, you can either provide it through the `keys` input, or use the layout as a form input for `reactive forms`. 
+#### 2.1.2 Static
+
+Earlier we mentioned that the layout is build up using a provided two dimensional array. Depending on whether you want this layout to be `static` or `editable`, we provide the array in a different fashion.
+
+When making a `static` layout, the layout itself can not be readjusted on the spot by the end user. A good use-case for this could be a dashboard that comes with a predefined set of layouts the user can pick from.
+
+When the `layoutType` of the `ngx-configurable-layout` is set to `static`, the two dimensional array needs to provided through a `keys` input. This input takes a two dimensional array of key strings that match the ones presented in the template.
+
+Below is a simple example for a static configurable layout.
 
 ```ts
 import { NgxConfigurableLayoutComponent, NgxConfigurableLayoutItemComponent } from '@studiohyperdrive/ngx-layout';
@@ -36,7 +44,7 @@ import { NgxConfigurableLayoutComponent, NgxConfigurableLayoutItemComponent } fr
 ```
 
 ```html
-<ngx-configurable-layout [keys]="[['second-item', 'first-item'], ['third-item']]">
+<ngx-configurable-layout layoutType="static" [keys]="[['second-item', 'first-item'], ['third-item']]">
 	<ngx-configurable-layout-item key="first-item">
 		<p>This is the second item in the DOM.</p>
 	</ngx-configurable-layout-item>
@@ -51,7 +59,60 @@ import { NgxConfigurableLayoutComponent, NgxConfigurableLayoutItemComponent } fr
 </ngx-configurable-layout>
 ```
 
-#### 2.1.2 Item size
+#### 2.1.3 Editable
+
+Unlike with the `static` layout, the `editable` layout allows the user to readjust on the spot by the end user. This means that the end user can toggle items and ,when enabled, reorder these items through drag and drop. A use-case that fits this approach is a fully configurable dashboard, where an end user can pick and choose which items they wish to see.
+
+When setting the `layoutType` to `editable`, the two dimensional array is provided by attaching a `FormControl` to the `ngx-configurable-layout`. Unlike with the `keys` input, the control expects an object with a `key` and an `isActive` property. The latter will be used to let the end user toggle items within the view.
+
+As long as the `showInactive` property is set to false, the inactive items will not be shown in the view. By setting it to true, the inactive items become visible, including a toggle that gets attached to all the items in the view. This toggle allows the items in the view be toggled on and off.
+
+If you for some reason do not wish to make an item in the list toggable, you can set individual items in the control as disabled. You can do this by simply setting the `disabled` property of the item in the two dimensional array to true. This will prevent the toggle from being shown and the corresponding item will receive the class `ngx-layout-item-disabled`.
+
+By default, the toggle is represented by a default html checkbox in the top right corner of the item. This checkbox has the `ngx-layout-item-toggle` class. This toggle however can be overwritten by using the custom `checkboxTmpl` template. 
+
+Below is a simple example for an editable configurable layout.
+
+```ts
+import { NgxConfigurableLayoutComponent, NgxConfigurableLayoutItemComponent,NgxConfigurableLayoutGrid } from '@studiohyperdrive/ngx-layout';
+
+@Component({
+	...,
+	standalone: true,
+	imports: [NgxConfigurableLayoutComponent, NgxConfigurableLayoutItemComponent],
+	...
+})
+
+...
+
+public readonly control: FormControl<NgxConfigurableLayoutGrid> = new FormControl([[{key: 'second-item', isActive: true}, {key: 'first-item', isActive: false}, ]])
+```
+
+```html
+<ngx-configurable-layout layoutType="editable" [formControl]="control">
+	<ngx-configurable-layout-item key="first-item">
+		<p>This is the second item in the DOM. It will only be visible when the showInactive property is set to true.</p>
+	</ngx-configurable-layout-item>
+
+	<ngx-configurable-layout-item key="second-item">
+		<p>This is the first item in the DOM.</p>
+	</ngx-configurable-layout-item>
+
+    <ng-template #checkboxTmpl let-control>
+        This is an optional custom checkboxTmpl!
+
+        <input type="checkbox" [formControl]="control" class="my-custom-checkbox">
+    </ng-template>
+</ngx-configurable-layout>
+```
+
+#### 2.1.4 Drag and drop
+
+`ngx-configurable-layout` provides drag and drop through the Angular CDK implementation. By default, the drag and drop functionality is disabled, and can be enabled through `allowDragAndDrop`.
+
+By default, the package uses the demo styling provided by the Angular CDK team. This can be overwritten by custom styling, using the classes provided in the section `Styling`.
+
+#### 2.1.5 Item size
 
 To determine how much space an item takes up in the grid, we use the `itemSize` input.
 
@@ -61,19 +122,13 @@ By using the option `fit-content`, the size of the components themselves will de
 
 By using the option `equal`, all items in the entire grid will take up an equal amount of space. This also applies to the height of the elements, but this will require you to set the height of your items to `height:100%` for this to take effect.
 
-#### 2.1.3 Gaps
+#### 2.1.6 Gaps
 
 In order to create spacing between items in the layout, `ngx-configurable-layout` provides two inputs, `columnGap` and `rowGap`.
 
 Both properties expect a CSS based amount (in px, rem, %, etc.) and are both optional. This is the preferred way of adding spacing between your items, as using margins can sometimes create unexpected results due to the CSS Grid based implementation. 
 
-#### 2.1.4 Drag and drop
-
-`ngx-configurable-layout` provides drag and drop through the Angular CDK implementation. By default, the drag and drop functionality is disabled, and can be enabled through `alowDragAndDrop`.
-
-By default, the package uses the demo styling provided by the Angular CDK team. This can be overwritten by custom styling, using the classes provided in the section `Styling`.
-
-#### 2.1.5 Styling
+#### 2.1.7 Styling
 By default, `ngx-configurable-layout` always provides minimal styling. Several classes are provided to further style the grid as needed.
 
 | Class | |
@@ -82,3 +137,8 @@ By default, `ngx-configurable-layout` always provides minimal styling. Several c
 | ngx-layout-row | A row in the `ngx-configurable-layout` |
 | ngx-layout-item | A cell in the `ngx-configurable-layout` |
 | ngx-layout-drag-placeholder | A class to style the custom placeholder used when drag and drop is enabled. |
+| ngx-layout-item-toggle | A class to style the default checkbox used in `editable` layouts. |
+| ngx-layout-item-inactive | A class to style the inactive items used in `editable` layouts.|
+| ngx-layout-item-disabled | A class to style the disabled items used in `editable` layouts.|
+| ngx-layout-grid-inactive-shown | A class given to the container when the inactive items are being shown.|
+

--- a/projects/layout/package.json
+++ b/projects/layout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@studiohyperdrive/ngx-layout",
-	"version": "17.0.1",
+	"version": "17.1.0",
 	"peerDependencies": {
 		"@angular/common": "^17.0.4",
 		"@angular/core": "^17.0.4",

--- a/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.html
+++ b/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.html
@@ -3,6 +3,7 @@
 	class="ngx-layout-grid"
 	[class.ngx-layout-equal-size]="itemSize === 'equal'"
 	[style.row-gap]="rowGap"
+	[class.ngx-layout-grid-inactive-shown]="showInactive"
 >
 	<ul
 		*ngFor="let row of form.value; let index = index"
@@ -15,13 +16,38 @@
 		[style.column-gap]="columnGap"
 		(cdkDropListDropped)="drop($event)"
 	>
-		<ng-container *ngFor="let key of row">
-			<ng-container *ngIf="itemTemplateRecord()[key]">
-				<li cdkDrag class="ngx-layout-item" cdkDragPreviewContainer="parent">
-					<ng-template [ngTemplateOutlet]="itemTemplateRecord()[key]"></ng-template>
-					<div class="ngx-layout-drag-placeholder" *cdkDragPlaceholder></div>
-				</li>
+		<ng-container *ngFor="let item of row">
+			<ng-container *ngIf="itemTemplateRecord()[item.key]">
+				<ng-container *ngIf="showInactive || item.isActive">
+					<li
+						cdkDrag
+						class="ngx-layout-item"
+						[class.ngx-layout-item-inactive]="!item.isActive"
+						[class.ngx-layout-item-disabled]="item.disabled"
+						cdkDragPreviewContainer="parent"
+					>
+						<ng-template
+							[ngTemplateOutlet]="itemTemplateRecord()[item.key]"
+						></ng-template>
+
+						<ng-container *ngIf="!form.disabled && showInactive && !item.disabled">
+							<ng-template
+								[ngTemplateOutlet]="checkboxTemplate || defaultCheckBoxTmpl"
+								[ngTemplateOutletContext]="{
+									$implicit: isActiveFormRecord.controls[item.key]
+								}"
+							>
+							</ng-template>
+						</ng-container>
+
+						<div class="ngx-layout-drag-placeholder" *cdkDragPlaceholder></div>
+					</li>
+				</ng-container>
 			</ng-container>
 		</ng-container>
 	</ul>
 </div>
+
+<ng-template #defaultCheckBoxTmpl let-control>
+	<input class="ngx-layout-item-toggle" type="checkbox" [formControl]="control" />
+</ng-template>

--- a/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.scss
+++ b/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.scss
@@ -18,6 +18,8 @@
 	}
 
 	.ngx-layout-item {
+		position: relative;
+
 		padding: unset;
 		margin: unset;
 		min-height: max-content;
@@ -37,5 +39,11 @@
 		border: dotted 3px #999;
 		min-height: 60px;
 		transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+	}
+
+	.ngx-layout-item-toggle {
+		position: absolute;
+		top: 5px;
+		right: 5px;
 	}
 }

--- a/projects/layout/src/lib/pipes/item-size/item-size.pipe.ts
+++ b/projects/layout/src/lib/pipes/item-size/item-size.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { NgxConfigurableLayoutItemSizeOption } from '../../types';
+import { NgxConfigurableLayoutItemEntity, NgxConfigurableLayoutItemSizeOption } from '../../types';
 
 @Pipe({
 	name: 'ngxConfigurableLayoutItemSize',
@@ -13,7 +13,7 @@ export class NgxConfigurableLayoutItemSizePipe implements PipeTransform {
 	 * @param itemSize - The itemSize used by the layout
 	 */
 	transform(
-		keys: string[][],
+		keys: NgxConfigurableLayoutItemEntity[][],
 		itemSize: NgxConfigurableLayoutItemSizeOption
 	): Record<string, any> {
 		// Iben: If non data source is provided or if the itemSize is 'fill',

--- a/projects/layout/src/lib/types/configurable-layout.ts
+++ b/projects/layout/src/lib/types/configurable-layout.ts
@@ -1,1 +1,11 @@
 export type NgxConfigurableLayoutItemSizeOption = 'fit-content' | 'fill' | 'equal';
+
+export type NgxConfigurableLayoutType = 'static' | 'editable';
+
+export interface NgxConfigurableLayoutItemEntity {
+	key: string;
+	isActive: boolean;
+	disabled?: boolean;
+}
+
+export type NgxConfigurableLayoutGrid = NgxConfigurableLayoutItemEntity[][];


### PR DESCRIPTION
Updates the ngx-layout package so that the configurable layout now has two options, `static` or `editable`.

![afbeelding](https://github.com/studiohyperdrive/ngx-tools/assets/10544531/25a80746-739d-4dff-b40b-ba8e3f8a07c5)
