### PR TITLE
fix(ngx-layout): Include the isActive state in the equal layout sizing

### DIFF
--- a/projects/layout-test/src/app/app.component.ts
+++ b/projects/layout-test/src/app/app.component.ts
@@ -24,11 +24,9 @@ export class AppComponent {
 		[
 			{ key: '1', isActive: true },
 			{ key: '2', isActive: true },
+			{ key: 'a', isActive: false },
 		],
-		[
-			{ key: 'a', isActive: true },
-			{ key: 'b', isActive: false },
-		],
+		[{ key: 'b', isActive: true }],
 	]);
 	public isActive: FormControl<boolean> = new FormControl(false);
 	public dragAndDrop: FormControl<boolean> = new FormControl(false);

--- a/projects/layout/package.json
+++ b/projects/layout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@studiohyperdrive/ngx-layout",
-	"version": "17.1.0",
+	"version": "17.1.1",
 	"peerDependencies": {
 		"@angular/common": "^17.0.4",
 		"@angular/core": "^17.0.4",

--- a/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.html
+++ b/projects/layout/src/lib/components/configurable-layout/configurable-layout.component.html
@@ -12,7 +12,7 @@
 		cdkDropListOrientation="horizontal"
 		[cdkDropListDisabled]="!allowDragAndDrop && !form.disabled"
 		[id]="'ngx-layout-row-' + index"
-		[ngStyle]="form.value | ngxConfigurableLayoutItemSize : itemSize"
+		[ngStyle]="{keys: form.value, showInactive} | ngxConfigurableLayoutItemSize : itemSize"
 		[style.column-gap]="columnGap"
 		(cdkDropListDropped)="drop($event)"
 	>

--- a/projects/layout/src/lib/pipes/item-size/item-size.pipe.ts
+++ b/projects/layout/src/lib/pipes/item-size/item-size.pipe.ts
@@ -10,10 +10,14 @@ export class NgxConfigurableLayoutItemSizePipe implements PipeTransform {
 	 * Returns the needed styling for the ngx-configurable-layout component
 	 *
 	 * @param keys - The keys used in the grid
+	 * @param showInactive - Whether we want to show inactive items
 	 * @param itemSize - The itemSize used by the layout
 	 */
 	transform(
-		keys: NgxConfigurableLayoutItemEntity[][],
+		{
+			keys,
+			showInactive,
+		}: { keys: NgxConfigurableLayoutItemEntity[][]; showInactive: boolean },
 		itemSize: NgxConfigurableLayoutItemSizeOption
 	): Record<string, any> {
 		// Iben: If non data source is provided or if the itemSize is 'fill',
@@ -31,7 +35,17 @@ export class NgxConfigurableLayoutItemSizePipe implements PipeTransform {
 
 		// Iben: If itemSize is 'equal', all items in the grid need to be of equal size.
 		// For this, we grab the row with the largest amount of items, which will define the amount of columns
-		const longestRow = Math.max(...[...keys].map((item) => item.length));
+		const longestRow = Math.max(
+			...[...keys].map((item) => {
+				return item.filter((key) => {
+					if (!showInactive) {
+						return key.isActive;
+					}
+
+					return true;
+				}).length;
+			})
+		);
 
 		return {
 			'grid-template-columns': `repeat(${longestRow}, minmax(0, 1fr))`,


### PR DESCRIPTION
Fixes the equal sizing to also include the isActive state, which would result in incorrect views without it.

![afbeelding](https://github.com/studiohyperdrive/ngx-tools/assets/10544531/8bf47d85-1f17-429e-a3d2-3177c5420dab)
![afbeelding](https://github.com/studiohyperdrive/ngx-tools/assets/10544531/fa141217-67fd-4fe3-ad3b-c1bb39d94b5c)
