### PR TITLE
fix(ngx-layout): Fix unnecessary emits in the ngx-configurable-layout

### DIFF
--- a/projects/layout-test/src/app/app.component.ts
+++ b/projects/layout-test/src/app/app.component.ts
@@ -20,14 +20,22 @@ import {
 	],
 })
 export class AppComponent {
-	public control: FormControl<NgxConfigurableLayoutGrid> = new FormControl([
-		[
-			{ key: '1', isActive: true },
-			{ key: '2', isActive: true },
-			{ key: 'a', isActive: false },
-		],
-		[{ key: 'b', isActive: true }],
-	]);
+	public control: FormControl<NgxConfigurableLayoutGrid> = new FormControl([]);
 	public isActive: FormControl<boolean> = new FormControl(false);
 	public dragAndDrop: FormControl<boolean> = new FormControl(false);
+
+	ngOnInit() {
+		this.control.valueChanges.subscribe(console.log);
+
+		setTimeout(() => {
+			this.control.patchValue([
+				[
+					{ key: '1', isActive: true },
+					{ key: '2', isActive: true },
+					{ key: 'a', isActive: false },
+				],
+				[{ key: 'b', isActive: true }],
+			]);
+		}, 5000);
+	}
 }

--- a/projects/layout/package.json
+++ b/projects/layout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@studiohyperdrive/ngx-layout",
-	"version": "17.1.1",
+	"version": "17.1.2",
 	"peerDependencies": {
 		"@angular/common": "^17.0.4",
 		"@angular/core": "^17.0.4",


### PR DESCRIPTION
When the form gets patched after the initial writeValue, the form emitted unnecessarily.  This should be fixed.