### PR TITLE
Feature/ngx forms/compare validator

### DIFF
--- a/projects/forms/README.md
+++ b/projects/forms/README.md
@@ -18,6 +18,9 @@ A FormGroup validator that checks whether either all controls in a FormGroup are
 ### atLeastOneRequired
 A FormGroup validator that checks whether at least one of the provided controls was filled in. A separate function to determine the filled in state can be provided.
 
+### compareValidator
+A FormGroup validator that will compare child control values with a provided comparator.
+
 ### dependedRequired
 A FormGroup validator that checks whether a series of controls are filled in when another control was filled in. A separate function to determine the filled in state can be provided.
 

--- a/projects/forms/src/lib/validators/compare/compare.validator.spec.ts
+++ b/projects/forms/src/lib/validators/compare/compare.validator.spec.ts
@@ -1,0 +1,86 @@
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { CompareValidator } from './compare.validator';
+
+describe('CompareValidator', () => {
+	describe('without setErrorOnKey', () => {
+		let form: FormGroup;
+		beforeEach(() => {
+			form = new FormGroup(
+				{
+					controlA: new FormControl<number>(null),
+					controlB: new FormControl<number>(null),
+				},
+				[
+					CompareValidator<number>(
+						['controlA', 'controlB'],
+						(a: number, b: number) => a > b
+					),
+				]
+			);
+		});
+
+		it('should not give an error on a valid comparison', () => {
+			form.patchValue({
+				controlA: 5,
+				controlB: 6,
+			});
+
+			expect(form.getError('compareError')).toBe(null);
+			expect(form.get('controlA').getError('compareError')).toBe(null);
+			expect(form.get('controlB').getError('compareError')).toBe(null);
+		});
+
+		it('should give an error on an invalid comparison', () => {
+			form.patchValue({
+				controlA: 6,
+				controlB: 5,
+			});
+
+			expect(form.getError('compareError')).toBeTrue();
+			expect(form.get('controlA').getError('compareError')).toBe(null);
+			expect(form.get('controlB').getError('compareError')).toBe(null);
+		});
+	});
+
+	describe('with setErrorOnKey', () => {
+		let form: FormGroup;
+		beforeEach(() => {
+			form = new FormGroup(
+				{
+					controlA: new FormControl<number>(null),
+					controlB: new FormControl<number>(null),
+				},
+				[
+					CompareValidator<number>(
+						['controlA', 'controlB'],
+						(a: number, b: number) => a > b,
+						'controlA'
+					),
+				]
+			);
+		});
+
+		it('should not give an error on a valid comparison', () => {
+			form.patchValue({
+				controlA: 5,
+				controlB: 6,
+			});
+
+			expect(form.getError('compareError')).toBe(null);
+			expect(form.get('controlA').getError('compareError')).toBe(null);
+			expect(form.get('controlB').getError('compareError')).toBe(null);
+		});
+
+		it('should give an error on an invalid comparison', () => {
+			form.patchValue({
+				controlA: 6,
+				controlB: 5,
+			});
+
+			expect(form.getError('compareError')).toBeTrue();
+			expect(form.get('controlA').getError('compareError')).toBeTrue();
+			expect(form.get('controlB').getError('compareError')).toBe(null);
+		});
+	});
+});

--- a/projects/forms/src/lib/validators/compare/compare.validator.ts
+++ b/projects/forms/src/lib/validators/compare/compare.validator.ts
@@ -1,0 +1,56 @@
+import { FormControl, FormGroup, ValidationErrors } from '@angular/forms';
+
+import { clearFormError, setFormError } from '../utils';
+
+/**
+ * CompareValidator
+ *
+ * The CompareValidator will return a validator that compares the values of two FormControls
+ * within a FormGroup based on a given comparator function.
+ *
+ * Note: This validator will only set an error on the group it is set to
+ * unless the `setErrorOnKey` argument is given.
+ *
+ * @param keys {string[]}
+ * @param comparatorFn {(...args: ValueType[]) => boolean}
+ * @param setErrorOnKey {string}
+ * @returns {(group: FormGroup<{ [key: string]: FormControl<ValueType>; }>) => ValidationErrors}
+ */
+export const CompareValidator = <ValueType = unknown>(
+	keys: string[],
+	comparatorFn: (...args: ValueType[]) => boolean,
+	setErrorOnKey?: string
+): ((
+	group: FormGroup<{
+		[key: string]: FormControl<ValueType>;
+	}>
+) => ValidationErrors) => {
+	return (
+		group: FormGroup<{
+			[key: string]: FormControl<ValueType>;
+		}>
+	): ValidationErrors => {
+		// Denis: map the values to an array:
+		const values: ValueType[] = keys.map((key: string) => group?.get(key).getRawValue());
+		const setErrorOnKeyControl = group?.get(setErrorOnKey);
+
+		// Denis: check if any of the keys contains an undefined or null value:
+		if (values.some((value: ValueType) => typeof value === 'undefined' || value === null)) {
+			setErrorOnKeyControl && clearFormError(group.get(setErrorOnKey), 'compareError');
+
+			return null;
+		}
+
+		if (comparatorFn(...values)) {
+			setErrorOnKeyControl && setFormError(group.get(setErrorOnKey), 'compareError');
+
+			return {
+				compareError: true,
+			};
+		}
+
+		setErrorOnKeyControl && clearFormError(group.get(setErrorOnKey), 'compareError');
+
+		return null;
+	};
+};

--- a/projects/forms/src/lib/validators/validators.ts
+++ b/projects/forms/src/lib/validators/validators.ts
@@ -1,4 +1,10 @@
-import { AbstractControl, FormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
+import {
+	AbstractControl,
+	FormControl,
+	FormGroup,
+	ValidationErrors,
+	ValidatorFn,
+} from '@angular/forms';
 
 import { allOrNothingRequiredValidator } from './all-or-nothing-required/all-or-nothing-required.validator';
 import {
@@ -12,6 +18,7 @@ import { extendedEmailValidator } from './email/extended-email.validator';
 import { hasNoFutureDateValidator } from './has-no-future-date/has-no-future-date.validator';
 import { dateRangeValidator } from './date-range/date-range.validator';
 import { WordCountValidator } from './max-word-count/word-count.validator';
+import { CompareValidator } from './compare/compare.validator';
 
 /**
  * Exported Class
@@ -49,6 +56,31 @@ export class NgxValidators {
 		options?: AtLeastOneRequiredValidatorOptions<KeyType>
 	): ValidatorFn {
 		return atLeastOneRequiredValidator<KeyType>(options);
+	}
+
+	/**
+	 * The compareValidator will return a validator that compares the values of two FormControls
+	 * within a FormGroup based on a given comparator function.
+	 *
+	 * @param keys {string[]}
+	 * @param comparatorFn {(...args: ValueType[]) => boolean}
+	 * @param setErrorOnKey {string}
+	 * @returns {(group: FormGroup<{ [key: string]: FormControl<ValueType>; }>) => ValidationErrors}
+	 *
+	 * Note: This validator will only set an error on the group it is set to
+	 * unless the `setErrorOnKey` argument is given.
+	 *
+	 */
+	static compareValidator<ValueType = unknown>(
+		keys: string[],
+		comparatorFn: (...args: ValueType[]) => boolean,
+		setErrorOnKey?: string
+	): (
+		group: FormGroup<{
+			[key: string]: FormControl<ValueType>;
+		}>
+	) => ValidationErrors {
+		return CompareValidator(keys, comparatorFn, setErrorOnKey);
 	}
 
 	/**

--- a/projects/layout/src/lib/pipes/item-size/item-size.pipe.spec.ts
+++ b/projects/layout/src/lib/pipes/item-size/item-size.pipe.spec.ts
@@ -3,24 +3,96 @@ import { NgxConfigurableLayoutItemSizePipe } from './item-size.pipe';
 describe('NgxConfigurableLayoutItemSizePipe', () => {
 	const pipe = new NgxConfigurableLayoutItemSizePipe();
 
-	it('should return an empty object if the keys are not provided', () => {
+	it('should return an empty object if no arguments are provided', () => {
 		expect(pipe.transform(undefined, 'equal')).toEqual({});
 		expect(pipe.transform(undefined, 'fit-content')).toEqual({});
 		expect(pipe.transform(undefined, 'fill')).toEqual({});
 	});
 
+	it('should return an empty object if the keys are not provided', () => {
+		expect(
+			pipe.transform(
+				{
+					keys: undefined,
+					showInactive: true,
+				},
+				'equal'
+			)
+		).toEqual({});
+		expect(
+			pipe.transform(
+				{
+					keys: undefined,
+					showInactive: true,
+				},
+				'fit-content'
+			)
+		).toEqual({});
+		expect(
+			pipe.transform(
+				{
+					keys: undefined,
+					showInactive: true,
+				},
+				'fill'
+			)
+		).toEqual({});
+	});
+
 	it('should return an empty object if the itemSize is fill', () => {
-		expect(pipe.transform([['a'], ['b', 'c']], 'fill')).toEqual({});
+		expect(
+			pipe.transform(
+				{
+					keys: [
+						[{ key: 'a', isActive: true }],
+						[
+							{ key: 'b', isActive: true },
+							{ key: 'c', isActive: true },
+						],
+					],
+					showInactive: true,
+				},
+				'fill'
+			)
+		).toEqual({});
 	});
 
 	it('should return grid auto columns if the itemSize is fit-content', () => {
-		expect(pipe.transform([['a'], ['b', 'c']], 'fit-content')).toEqual({
+		expect(
+			pipe.transform(
+				{
+					keys: [
+						[{ key: 'a', isActive: true }],
+						[
+							{ key: 'b', isActive: true },
+							{ key: 'c', isActive: true },
+						],
+					],
+					showInactive: true,
+				},
+				'fit-content'
+			)
+		).toEqual({
 			'grid-auto-columns': 'max-content',
 		});
 	});
 
 	it('should return grid template columns if the itemSize is equal', () => {
-		expect(pipe.transform([['a'], ['b', 'c']], 'equal')).toEqual({
+		expect(
+			pipe.transform(
+				{
+					keys: [
+						[{ key: 'a', isActive: true }],
+						[
+							{ key: 'b', isActive: true },
+							{ key: 'c', isActive: true },
+						],
+					],
+					showInactive: true,
+				},
+				'equal'
+			)
+		).toEqual({
 			'grid-template-columns': 'repeat(2, minmax(0, 1fr))',
 		});
 	});

--- a/projects/layout/src/lib/pipes/item-size/item-size.pipe.ts
+++ b/projects/layout/src/lib/pipes/item-size/item-size.pipe.ts
@@ -17,7 +17,10 @@ export class NgxConfigurableLayoutItemSizePipe implements PipeTransform {
 		{
 			keys,
 			showInactive,
-		}: { keys: NgxConfigurableLayoutItemEntity[][]; showInactive: boolean },
+		}: { keys: NgxConfigurableLayoutItemEntity[][]; showInactive: boolean } = {
+			keys: null,
+			showInactive: true,
+		},
 		itemSize: NgxConfigurableLayoutItemSizeOption
 	): Record<string, any> {
 		// Iben: If non data source is provided or if the itemSize is 'fill',


### PR DESCRIPTION
This PR contains two commits.

# feat(ngx-forms): a compare validator has been added that compares child-control values
This commit adds a compare validator that can compare child controls of a group by means of a provided comparator function.

# fix(ngx-layout): the item-size pipe can now handle undefined arguments + fixed existing tests
This commit fixes existing layout item-size pipe unit tests & adds support for an undefined argument.