### PR TITLE
fix(ngx-forms): Fix touched, dirty and pristine states for FormAccessors

### DIFF
--- a/apps/form-test/src/app/app.component.html
+++ b/apps/form-test/src/app/app.component.html
@@ -5,3 +5,22 @@
 <button (click)="disableForm()">Disable/enable</button>
 
 <button (click)="markAllAsTouched(control)">Mark as touched</button>
+
+{{ control.value | json }}
+
+<hr />
+
+<div [formGroup]="form">
+	<label for="">
+		Start
+		<app-date-input formControlName="start" />
+	</label>
+
+	<label for="">
+		End
+		<app-date-input formControlName="end" />
+	</label>
+</div>
+
+<button (click)="form.get('start').markAsTouched()">Mark start as touched</button>
+<button (click)="form.get('end').markAsTouched()">Mark end as touched</button>

--- a/apps/form-test/src/app/app.component.ts
+++ b/apps/form-test/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { FormAccessorContainer } from '@ngx/forms';
 
 @Component({
@@ -9,6 +9,11 @@ import { FormAccessorContainer } from '@ngx/forms';
 })
 export class AppComponent extends FormAccessorContainer {
 	public readonly control = new FormControl();
+
+	public readonly form = new FormGroup({
+		start: new FormControl(''),
+		end: new FormControl(''),
+	});
 
 	checkValues() {
 		this.updateAllValueAndValidity(this.control);

--- a/apps/form-test/src/date-input/date-input.component.html
+++ b/apps/form-test/src/date-input/date-input.component.html
@@ -1,1 +1,2 @@
 <input type="date" [formControl]="form" (blur)="onTouch()" />
+Internal control touched: {{form.touched}}

--- a/libs/forms/README.md
+++ b/libs/forms/README.md
@@ -304,7 +304,7 @@ export class SurveyFormComponent
 
 ## 3. FormAccessorContainer
 
-In order to mark all controls of several (nested) `FormAccessors` as touched or dirty or update the value and validity, we use the `FormAccessorContainer`.
+In order to update the value and validity of all controls of several (nested) `FormAccessors`, we use the `FormAccessorContainer`.
 
 ### BaseFormAccessor
 
@@ -318,14 +318,6 @@ In order to reach all FormAccessors and their children, we need to provide the `
 			useExisting: forwardRef(() => BasicRegistrationDataFormComponent)
 		}
 ```
-
-### markAllAsTouched
-
-Calling this method on a `FormAccessorContainer` will recursively mark each `FormAccessor` and their corresponding `FormAccessor` children in the template as touched.
-
-### markAsDirty
-
-Calling this method on a `FormAccessorContainer` will recursively mark each `FormAccessor` and their corresponding `FormAccessor` children in the template as dirty.
 
 ### UpdateValueAndValidity
 

--- a/libs/forms/package.json
+++ b/libs/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@studiohyperdrive/ngx-forms",
 	"homepage": "https://github.com/studiohyperdrive/ngx-tools/blob/master/projects/forms/README.md",
-	"version": "17.5.0",
+	"version": "17.6.0",
 	"license": "MIT",
 	"peerDependencies": {
 		"@angular/common": "^17.0.4",

--- a/libs/forms/src/lib/abstracts/custom-control-value-accessor/custom-control-value-accessor.ts
+++ b/libs/forms/src/lib/abstracts/custom-control-value-accessor/custom-control-value-accessor.ts
@@ -1,0 +1,389 @@
+import {
+	ChangeDetectorRef,
+	Directive,
+	Injector,
+	Input,
+	OnDestroy,
+	Output,
+	QueryList,
+	ViewChildren,
+	inject,
+} from '@angular/core';
+import {
+	AbstractControl,
+	ControlValueAccessor,
+	FormControl,
+	NgControl,
+	ValidationErrors,
+} from '@angular/forms';
+
+import { BehaviorSubject, Observable, Subject, filter, takeUntil, tap } from 'rxjs';
+import { FormAccessorControlsEntity, FormStateOptionsEntity } from '../../interfaces';
+import { BaseFormAccessor } from '../base-form/base-form.accessor';
+import { DataFormAccessor } from '../data-form/data-form.accessor';
+import { FormAccessor } from '../form/form.accessor';
+import {
+	handleFormAccessorControlDisabling,
+	handleFormAccessorMarkAsDirty,
+	handleFormAccessorMarkAsPristine,
+	handleFormAccessorMarkAsTouched,
+	handleFormAccessorUpdateValueAndValidity,
+	hasErrors,
+} from '../../utils';
+
+@Directive()
+export abstract class NgxFormsControlValueAccessor<
+	DataType = unknown,
+	FormAccessorFormType extends AbstractControl = FormControl,
+	FormValueType = DataType
+> implements ControlValueAccessor, OnDestroy
+{
+	/**
+	 *  The Injector needed in the constructor
+	 */
+	private readonly injector: Injector = inject(Injector);
+
+	/**
+	 *  The ChangeDetector reference
+	 */
+	public readonly cdRef: ChangeDetectorRef = inject(ChangeDetectorRef);
+
+	/**
+	 * A subject to hold the parent control
+	 */
+	private readonly parentControlSubject$: Subject<AbstractControl> =
+		new Subject<AbstractControl>();
+
+	/**
+	 * A reference to the control tied to this control value accessor
+	 */
+	protected readonly parentControl$: Observable<AbstractControl> =
+		this.parentControlSubject$.pipe(filter(Boolean));
+
+	/**
+	 * Inner form to write to
+	 */
+	public form: FormAccessorFormType;
+
+	/**
+	 * Whether the first setDisable has run
+	 */
+	protected initialSetDisableHasRun: boolean = false;
+
+	/**
+	 * On destroy flow handler
+	 */
+	protected readonly destroy$ = new Subject();
+
+	/**
+	 * Subject to check whether the form is initialized
+	 */
+	protected readonly initializedSubject$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
+		false
+	);
+
+	/**
+	 * Whether or not we want to emit a value when we use the disableFields, by default this will emit
+	 *
+	 * @param  keys - Keys we're about to disable
+	 */
+	protected emitValueWhenDisableFieldsUsingInput?(
+		keys: FormAccessorControlsEntity<FormAccessorFormType>[]
+	): boolean;
+
+	/**
+	 * A list of all DataFormAccessors en FormAccessors of this component
+	 */
+	@ViewChildren(BaseFormAccessor) accessors: QueryList<DataFormAccessor | FormAccessor>;
+
+	/**
+	 * Keys of the fields we wish to disable.
+	 * By default this will emit a valueChanges, this can be overwritten by the emitValueWhenDisableFieldsUsingInput in the Accessor
+	 *
+	 * @memberof FormAccessor
+	 */
+	@Input() set disableFields(keys: FormAccessorControlsEntity<FormAccessorFormType>[]) {
+		// Iben: Early exit in case the keys are not provided
+		if (!keys) {
+			return;
+		}
+
+		// Iben: Setup a subject to track whether we're still disabling the fields
+		const disabling = new Subject();
+
+		// Iben: Add the keys to a set for more performant lookup and convert those to a string to not have Typescript issues later down the line
+		const controlKeys = new Set(keys);
+
+		// Iben: Check if we need to dispatch the disable or enable event
+		const emitEvent = this.emitValueWhenDisableFieldsUsingInput
+			? this.emitValueWhenDisableFieldsUsingInput(keys)
+			: true;
+
+		// Iben: Listen to the initialized state of the form
+		this.initialized$
+			.pipe(
+				filter(Boolean),
+				tap(() => {
+					// TODO: Iben: Remove this setTimeout once we're in a Signal based component
+					setTimeout(() => {
+						// Iben: Handle the disabling of the fields
+						handleFormAccessorControlDisabling(this.form, controlKeys, emitEvent);
+					});
+
+					// Iben: Set the disabling subject so that we can complete this subscription
+					disabling.next(undefined);
+					disabling.complete();
+				}),
+				takeUntil(disabling)
+			)
+			.subscribe();
+	}
+
+	/**
+	 * Whether we want to skip the first setDisable (https://github.com/angular/angular/pull/47576).
+	 * By default, this is true
+	 */
+	@Input() public skipInitialSetDisable: boolean = true;
+
+	/**
+	 * Stream to know whether the form has been initialized
+	 */
+	@Output()
+	public readonly initialized$: Observable<boolean> = this.initializedSubject$.asObservable();
+
+	constructor() {
+		// Iben: Use setTimeOut to avoid the circular dependency issue
+		setTimeout(() => {
+			const parentControl = this.injector.get(NgControl);
+
+			// Iben: If for some reason we can't find the control or the ngControl, early exit and throw an error
+			if (!parentControl?.control) {
+				console.error(
+					'NgxForms: No control was found after initializing. Check if a control was assigned to the FormAccessor.'
+				);
+
+				return;
+			}
+
+			this.parentControlSubject$.next(parentControl.control);
+
+			// Iben: Grab the control from the parent container
+			const control = parentControl.control;
+
+			// Iben: Setup the markAsTouched flow
+			// Iben: Keep a reference to the original `markAsTouched` handler.
+			const markAsTouched = control.markAsTouched.bind(control);
+
+			// Iben: Override the `markAsTouched` handler with our own.
+			control.markAsTouched = (options?: FormStateOptionsEntity) => {
+				// Iben: If the control is already marked as touched, we early exit
+				if (control.touched) {
+					return;
+				}
+
+				// Iben: Invoke the original `markAsTouchedHandler`.
+				markAsTouched(options);
+
+				// Iben: If the onlySelf flag is set to true, we early exit
+				if (options?.onlySelf) {
+					return;
+				}
+
+				// Iben: Invoke the custom `markAsTouchedHandler`.
+				this.markAsTouched(options);
+			};
+
+			// Iben: Setup the markAsDirty flow
+			// Iben: Keep a reference to the original `markAsDirty` handler.
+			const markAsDirty = control.markAsDirty.bind(control);
+
+			// Iben: Override the `markAsDirty` handler with our own.
+			control.markAsDirty = (options?: FormStateOptionsEntity) => {
+				// Iben: If the control is already marked as dirty, we early exit
+				if (control.dirty) {
+					return;
+				}
+
+				// Iben: Invoke the original `markAsDirtyHandler`.
+				markAsDirty(options);
+
+				// Iben: If the onlySelf flag is set to true, we early exit
+				if (options?.onlySelf) {
+					return;
+				}
+
+				// Iben: Invoke the custom `markAsDirtyHandler`.
+				this.markAsDirty(options);
+			};
+
+			// Iben: Setup the markAsPristine flow
+			// Iben: Keep a reference to the original `markAsPristine` handler.
+			const markAsPristine = control.markAsPristine.bind(control);
+
+			// Iben: Override the `markAsPristine` handler with our own.
+			control.markAsPristine = (options?: FormStateOptionsEntity) => {
+				// Iben: If the control is already marked as pristine, we early exit
+				if (control.pristine) {
+					return;
+				}
+
+				// Iben: Invoke the original `markAsPristineHandler`.
+				markAsPristine(options);
+
+				// Iben: If the onlySelf flag is set to true, we early exit
+				if (options?.onlySelf) {
+					return;
+				}
+
+				// Iben: Invoke the custom `markAsPristineHandler`.
+				this.markAsPristine(options);
+			};
+		});
+	}
+
+	/**
+	 * Sets up the ControlValueAccessor connectors
+	 */
+	public onTouch: Function = () => {}; // tslint:disable-line:no-empty
+	public onChange: Function = (_: any) => {}; // tslint:disable-line:no-empty
+
+	public registerOnChange(fn: any): void {
+		this.onChange = fn;
+	}
+
+	public registerOnTouched(fn: any): void {
+		this.onTouch = fn;
+	}
+
+	/**
+	 * Writes value to the inner form
+	 *
+	 * @param value - Value to patch in the inner form
+	 */
+	public writeValue(value: DataType | undefined | null): void {
+		// Iben: Early exit in case the form was not found
+		if (!this.form) {
+			console.error(
+				'NgxForms: No form was found when trying to write a value. This error can occur when overwriting the ngOnInit without invoking super.OnInit().'
+			);
+
+			return;
+		}
+
+		// Iben: Reset the current form without emitEvent to not trigger the valueChanges
+		this.form.reset(undefined, { emitEvent: false });
+
+		// Iben: Patch the current form with the new value without emitEvent to not trigger the valueChanges
+		if (value !== undefined && value !== null) {
+			this.form.patchValue(this.onWriteValueMapper ? this.onWriteValueMapper(value) : value, {
+				emitEvent: false,
+			});
+		}
+
+		// Iben: Validate the current value
+		this.validate();
+
+		// Iben: Detect changes so the changes are visible in the dom
+		this.cdRef.detectChanges();
+	}
+
+	/**
+	 * Mark all controls of the form as touched
+	 */
+	public markAsTouched(options: FormStateOptionsEntity = {}): void {
+		handleFormAccessorMarkAsTouched(this.form, this.accessors?.toArray() || [], options);
+
+		// Iben: Detect changes so the changes are visible in the dom
+		this.cdRef.detectChanges();
+	}
+
+	/**
+	 * Mark all controls of the form as dirty
+	 */
+	public markAsDirty(options: FormStateOptionsEntity = {}): void {
+		handleFormAccessorMarkAsDirty(this.form, this.accessors?.toArray() || [], options);
+
+		// Iben: Detect changes so the changes are visible in the dom
+		this.cdRef.detectChanges();
+	}
+
+	/**
+	 * Mark all controls of the form as pristine
+	 */
+	public markAsPristine(options: FormStateOptionsEntity = {}): void {
+		handleFormAccessorMarkAsPristine(this.form, this.accessors?.toArray() || [], options);
+
+		// Iben: Detect changes so the changes are visible in the dom
+		this.cdRef.detectChanges();
+	}
+
+	/**
+	 * Update the value and validity of the provided form
+	 */
+	public updateAllValueAndValidity(options: FormStateOptionsEntity): void {
+		handleFormAccessorUpdateValueAndValidity(
+			this.form,
+			this.accessors?.toArray() || [],
+			options
+		);
+
+		// Iben: Detect changes so the changes are visible in the dom
+		this.cdRef.detectChanges();
+	}
+
+	/**
+	 * Validates the inner form
+	 */
+	public validate(): ValidationErrors | null {
+		// Iben: If the form itself is invalid, we return the invalidForm: true right away
+		if (this.form.invalid) {
+			return { invalidForm: true };
+		}
+
+		// Iben: In case the form is invalid, we check if the child controls are possibly invalid
+		return hasErrors(this.form) ? { invalidForm: true } : null;
+	}
+
+	/**
+	 * Disables/enables the inner form based on the passed value
+	 *
+	 * @param isDisabled - Whether or not the form should be disabled
+	 */
+	public setDisabledState(isDisabled: boolean) {
+		// Iben: Skip the initial setDisabled, as this messes up our form approach.
+		// https://github.com/angular/angular/pull/47576
+		if (this.skipInitialSetDisable && !this.initialSetDisableHasRun) {
+			this.initialSetDisableHasRun = true;
+
+			return;
+		}
+
+		if (isDisabled) {
+			this.form.disable({ emitEvent: false });
+		} else {
+			this.form.enable({ emitEvent: false });
+		}
+
+		// Iben: Detect changes so the changes are visible in the dom
+		this.cdRef.detectChanges();
+	}
+
+	/**
+	 * Optional method to map the inner form value to an outer form specific format
+	 *
+	 * @param value - Value from the form
+	 */
+	public onChangeMapper?(value: Partial<FormValueType>): DataType;
+
+	/**
+	 * Optional method to map the outer form value to an inner form specific format
+	 *
+	 * @param value - Value from the form
+	 */
+	public onWriteValueMapper?(value: DataType): FormValueType;
+
+	public ngOnDestroy(): void {
+		this.destroy$.next(undefined);
+		this.destroy$.complete();
+	}
+}

--- a/libs/forms/src/lib/abstracts/custom-control-value-accessor/index.ts
+++ b/libs/forms/src/lib/abstracts/custom-control-value-accessor/index.ts
@@ -1,0 +1,1 @@
+export * from './custom-control-value-accessor';

--- a/libs/forms/src/lib/abstracts/data-form/data-form.accessor.spec.ts
+++ b/libs/forms/src/lib/abstracts/data-form/data-form.accessor.spec.ts
@@ -1,254 +1,57 @@
-import { ChangeDetectorRef, Component, forwardRef, Injector } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import {
-	ControlContainer,
-	FormControl,
-	FormGroup,
-	NG_VALUE_ACCESSOR,
-	ReactiveFormsModule,
-	Validators,
-} from '@angular/forms';
+import { ChangeDetectorRef, Component, Injector } from '@angular/core';
+import { FormControl, FormGroup, NgControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { createAccessorProviders } from '../../utils';
 import { DataFormAccessor } from './data-form.accessor';
 
-const keys = ['hello', 'world'];
+@Component({
+	selector: 'kp-form-accessor',
+	template: ``,
+	providers: [createAccessorProviders(FormAccessorComponent)],
+})
+export class FormAccessorComponent extends DataFormAccessor<string[], any, any> {
+	initForm(data: string[]) {
+		const result = new FormGroup({});
 
-describe('DataFormAccessor', () => {
-	@Component({
-		selector: 'kp-forms-component',
-		template: '',
-		providers: [
-			{
-				provide: NG_VALUE_ACCESSOR,
-				useExisting: forwardRef(() => TestComponent),
-				multi: true,
-			},
-		],
-	})
-	class TestComponent extends DataFormAccessor<
-		string[],
-		Record<string, string>,
-		FormGroup<{ [key: string]: FormControl<string> }>
-	> {
-		constructor(cdRef: ChangeDetectorRef) {
-			super(cdRef);
-		}
-
-		initForm(data: string[]): FormGroup {
-			const result = new FormGroup({});
-
-			data.forEach((key) => {
-				result.addControl(key, new FormControl('', Validators.required));
-			});
-
-			return result;
-		}
-	}
-
-	let fixture: ComponentFixture<TestComponent>;
-	let component: TestComponent;
-
-	beforeEach(() => {
-		const testBed = TestBed.configureTestingModule({
-			declarations: [TestComponent],
-			imports: [ReactiveFormsModule],
-			providers: [ControlContainer],
+		data.forEach((item) => {
+			result.addControl(
+				item,
+				new FormGroup({
+					hello: new FormControl(null, [Validators.required, Validators.email]),
+					world: new FormControl(null, Validators.minLength(3)),
+				})
+			);
 		});
 
-		fixture = testBed.createComponent(TestComponent);
-		component = fixture.componentInstance;
-		(component as any).onChange = jasmine.createSpy();
-		component.data = keys;
-	});
-
-	describe('writeValue', () => {
-		it('should not call the `onChange` method when the writeValue is called', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			// Iben: Set the component data
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-			component.writeValue({ hello: 'test' });
-
-			expect(component.form.value).toEqual({ hello: 'test', world: null });
-			expect((component as any).onChange).not.toHaveBeenCalled();
-		}));
-	});
-
-	describe('setDisabledState', () => {
-		it('should not call the `onChange` method when setDisabledState is called', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.setDisabledState(false);
-
-			expect((component as any).onChange).not.toHaveBeenCalled();
-		}));
-	});
-
-	describe('onChange', () => {
-		it('should call the `onChange` if the form gets changed', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.form.patchValue({ hello: 'test' });
-
-			expect((component as any).onChange).toHaveBeenCalledWith({ hello: 'test', world: '' });
-		}));
-	});
-
-	describe('markAsTouched/markAsPristine', () => {
-		it('should set the form and its controls to touched when markAsTouched has been called', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.markAsTouched();
-
-			expect(component.form.touched).toBe(true);
-			expect(component.form.get('hello').touched).toBe(true);
-		}));
-	});
-
-	describe('validate', () => {
-		it('should call the `validate` method with the correct output when the form is valid', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.form.patchValue({});
-
-			expect(component.validate()).toEqual({ invalidForm: true });
-		}));
-
-		it('should call the `validate` method with the correct output when the form is invalid', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			expect(component.validate()).toEqual({ invalidForm: true });
-		}));
-	});
-});
-
-describe('DataFormAccessor with mappers', () => {
-	@Component({
-		selector: 'kp-forms-component',
-		template: '',
-		providers: [
-			{
-				provide: NG_VALUE_ACCESSOR,
-				useExisting: forwardRef(() => TestComponent),
-				multi: true,
-			},
-		],
-	})
-	class TestComponent extends DataFormAccessor<
-		string[],
-		[string, string][],
-		FormGroup<{ [key: string]: FormControl<string> }>,
-		Record<string, string>
-	> {
-		constructor(injector: Injector, cdRef: ChangeDetectorRef) {
-			super(cdRef);
-		}
-
-		initForm(data: string[]): FormGroup {
-			const result = new FormGroup({});
-
-			data.forEach((key) => {
-				result.addControl(key, new FormControl('', Validators.required));
-			});
-
-			return result;
-		}
-
-		onWriteValueMapper(values: [string, string][]) {
-			return values.reduce((previous, current) => {
-				return {
-					...previous,
-					[current[0]]: current[1],
-				};
-			}, {});
-		}
-
-		onChangeMapper(value: Record<string, string>): [string, string][] {
-			return Object.entries(value);
-		}
+		return result;
 	}
+}
 
-	let fixture: ComponentFixture<TestComponent>;
-	let component: TestComponent;
+describe('FormAccessor', () => {
+	let fixture: ComponentFixture<FormAccessorComponent>;
+	let component: FormAccessorComponent;
 
 	beforeEach(() => {
-		const testBed = TestBed.configureTestingModule({
-			declarations: [TestComponent],
+		TestBed.configureTestingModule({
+			declarations: [FormAccessorComponent],
 			imports: [ReactiveFormsModule],
-			providers: [ControlContainer],
+			providers: [ChangeDetectorRef, Injector, NgControl],
 		});
 
-		fixture = testBed.createComponent(TestComponent);
+		fixture = TestBed.createComponent(FormAccessorComponent);
 		component = fixture.componentInstance;
-		(component as any).onChange = jasmine.createSpy();
-		component.data = keys;
+
+		try {
+			fixture.detectChanges();
+		} catch (error) {}
 	});
 
-	describe('writeValue', () => {
-		it('should set the form with the mapped value', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-			component.writeValue([['hello', 'test']]);
-
-			expect(component.form.value).toEqual({ hello: 'test', world: null });
-		}));
-	});
-
-	describe('onChange', () => {
-		it('should call the `onChange` with the mapped value', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.form.patchValue({ hello: 'test' });
-
-			expect((component as any).onChange).toHaveBeenCalledWith([
-				['hello', 'test'],
-				['world', ''],
-			]);
-		}));
+	it('should create the form on the provided data', () => {
+		component.data = ['test', 'hello'];
+		expect(component.form.get('test.world')).toBeDefined();
+		expect(component.form.get('test.hello')).toBeDefined();
+		expect(component.form.get('hello.world')).toBeDefined();
+		expect(component.form.get('hello.hello')).toBeDefined();
 	});
 });

--- a/libs/forms/src/lib/abstracts/data-form/data-form.accessor.ts
+++ b/libs/forms/src/lib/abstracts/data-form/data-form.accessor.ts
@@ -1,32 +1,9 @@
-import {
-	ChangeDetectorRef,
-	Directive,
-	Input,
-	OnDestroy,
-	Output,
-	QueryList,
-	ViewChildren,
-} from '@angular/core';
-import {
-	AbstractControl,
-	ControlValueAccessor,
-	FormControl,
-	ValidationErrors,
-} from '@angular/forms';
+import { Directive, Input } from '@angular/core';
+import { AbstractControl, FormControl } from '@angular/forms';
 import { isEqual } from 'lodash';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { filter, takeUntil, tap } from 'rxjs/operators';
+import { takeUntil, tap } from 'rxjs/operators';
 
-import { BaseFormAccessor } from '../base-form/base-form.accessor';
-import { FormAccessor } from '../form/form.accessor';
-import { FormStateOptionsEntity, FormAccessorControlsEntity } from '../../interfaces';
-import {
-	handleFormAccessorControlDisabling,
-	handleFormAccessorMarkAsTouched,
-	handleFormAccessorMarkAsDirty,
-	hasErrors,
-	handleFormAccessorUpdateValueAndValidity,
-} from '../../utils';
+import { NgxFormsControlValueAccessor } from '../custom-control-value-accessor';
 
 @Directive()
 export abstract class DataFormAccessor<
@@ -34,121 +11,14 @@ export abstract class DataFormAccessor<
 	DataType = unknown,
 	FormAccessorFormType extends AbstractControl = FormControl,
 	FormValueType = DataType
-> implements OnDestroy, ControlValueAccessor
-{
-	/**
-	 * A list of all DataFormAccessors en FormAccessors of this component
-	 */
-	@ViewChildren(BaseFormAccessor) accessors: QueryList<DataFormAccessor | FormAccessor>;
-
+> extends NgxFormsControlValueAccessor<DataType, FormAccessorFormType, FormValueType> {
 	// Iben: Keep a reference to the current data so we don't make a new form if the data itself hasn't changed
 	private currentData: ConstructionDataType;
-
-	/**
-	 * Whether the first setDisable has run
-	 */
-	private initialSetDisableHasRun: boolean = false;
-
-	// On destroy flow handler
-	protected readonly destroy$ = new Subject();
-
-	// Subject to check whether the form is initialized
-	protected readonly initializedSubject$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
-		false
-	);
-
-	/**
-	 * Whether we want to skip the first setDisable (https://github.com/angular/angular/pull/47576).
-	 * By default, this is true
-	 */
-	@Input() public skipInitialSetDisable: boolean = true;
-
-	/**
-	 * Stream to know whether the form has been initialized
-	 */
-	@Output()
-	public readonly initialized$: Observable<boolean> = this.initializedSubject$.asObservable();
-
-	/**
-	 * Inner form to write to
-	 */
-	form: FormAccessorFormType;
 
 	/**
 	 * Method to set up the inner form
 	 */
 	abstract initForm(data: ConstructionDataType): FormAccessorFormType;
-
-	/**
-	 * Optional method to map the inner form value to an outer form specific format
-	 *
-	 * @param value - Value from the form
-	 */
-	public onChangeMapper?(value: Partial<FormValueType>): DataType;
-
-	/**
-	 * Optional method to map the outer form value to an inner form specific format
-	 *
-	 * @param value - Value from the form
-	 */
-	public onWriteValueMapper?(value: DataType): FormValueType;
-
-	/**
-	 * An optional handler to call right before the value and validity is updated
-	 *
-	 * @param options - The options passed to the updateValueAndValidity function
-
-	/**
-	 * Whether or not we want to emit a value when we use the disableFields, by default this will emit
-	 *
-	 * @param  keys - Keys we're about to disable
-	 */
-	protected emitValueWhenDisableFieldsUsingInput?(
-		keys: FormAccessorControlsEntity<FormAccessorFormType>[]
-	): boolean;
-
-	/**
-	 * Keys of the fields we wish to disable.
-	 * By default this will emit a valueChanges, this can be overwritten by the emitValueWhenDisableFieldsUsingInput in the Accessor
-	 *
-	 * @memberof FormAccessor
-	 */
-	@Input() set disableFields(keys: FormAccessorControlsEntity<FormAccessorFormType>[]) {
-		// Iben: Early exit in case the keys are not provided
-		if (!keys) {
-			return;
-		}
-
-		// Iben: Setup a subject to track whether we're still disabling the fields
-		const disabling = new Subject();
-
-		// Iben: Add the keys to a set for more performant lookup and convert those to a string to not have Typescript issues later down the line
-		const controlKeys = new Set(keys);
-
-		// Iben: Check if we need to dispatch the disable or enable event
-		const emitEvent = this.emitValueWhenDisableFieldsUsingInput
-			? this.emitValueWhenDisableFieldsUsingInput(keys)
-			: true;
-
-		// Iben: Listen to the initialized state of the form
-		this.initialized$
-			.pipe(
-				filter(Boolean),
-				tap(() => {
-					// TODO: Iben: Remove this setTimeout once we're in a Signal based component
-					setTimeout(() => {
-						// Iben: Handle the disabling of the fields
-						handleFormAccessorControlDisabling(this.form, controlKeys, emitEvent);
-					});
-
-					// Iben: Set the disabling subject so that we can complete this subscription
-					disabling.next(undefined);
-					disabling.complete();
-				}),
-				takeUntil(disabling)
-			)
-			.subscribe();
-	}
 
 	@Input({ required: true }) public set data(data: ConstructionDataType) {
 		// Iben: If we already have current data and the current data matches the new data, we don't make a new form
@@ -192,129 +62,6 @@ export abstract class DataFormAccessor<
 				takeUntil(this.destroy$)
 			)
 			.subscribe();
-	}
-
-	constructor(readonly cdRef: ChangeDetectorRef) {}
-
-	/**
-	 * Marks the control attached to this accessor as touched
-	 */
-	public onTouch: Function = () => {}; // tslint:disable-line:no-empty
-	private onChange: Function = (_: any) => {}; // tslint:disable-line:no-empty
-
-	public registerOnChange(fn: any): void {
-		this.onChange = fn;
-	}
-	public registerOnTouched(fn: any): void {
-		this.onTouch = fn;
-	}
-
-	/**
-	 * Writes value to the inner form
-	 *
-	 * @param value - Value to patch in the inner form
-	 */
-	public writeValue(value: DataType | undefined | null): void {
-		// Iben: Early exit in case the form was not found
-		if (!this.form) {
-			console.error(
-				'NgxForms: No form was found when trying to write a value. This error can occur when overwriting the ngOnInit without invoking super.OnInit().'
-			);
-
-			return;
-		}
-
-		// Iben: Reset the current form without emitEvent to not trigger the valueChanges
-		this.form.reset(undefined, { emitEvent: false });
-
-		// Iben: Patch the current form with the new value without emitEvent to not trigger the valueChanges
-		if (value !== undefined && value !== null) {
-			this.form.patchValue(this.onWriteValueMapper ? this.onWriteValueMapper(value) : value, {
-				emitEvent: false,
-			});
-		}
-
-		// Iben: Validate the current value
-		this.validate();
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Mark all controls of the form as touched
-	 */
-	public markAsTouched(options: FormStateOptionsEntity = {}): void {
-		handleFormAccessorMarkAsTouched(this.form, this.accessors?.toArray() || [], options);
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Mark all controls of the form as dirty
-	 */
-	public markAsDirty(options: FormStateOptionsEntity): void {
-		handleFormAccessorMarkAsDirty(this.form, this.accessors?.toArray() || [], options);
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Update the value and validity of the provided form
-	 */
-	public updateAllValueAndValidity(options: FormStateOptionsEntity): void {
-		handleFormAccessorUpdateValueAndValidity(
-			this.form,
-			this.accessors?.toArray() || [],
-			options
-		);
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Disables/enables the inner form based on the passed value
-	 *
-	 * @param isDisabled - Whether or not the form should be disabled
-	 */
-	public setDisabledState(isDisabled: boolean) {
-		// Iben: Skip the initial setDisabled, as this messes up our form approach.
-		// https://github.com/angular/angular/pull/47576
-		if (this.skipInitialSetDisable && !this.initialSetDisableHasRun) {
-			this.initialSetDisableHasRun = true;
-
-			return;
-		}
-
-		if (isDisabled) {
-			this.form.disable({ emitEvent: false });
-		} else {
-			this.form.enable({ emitEvent: false });
-		}
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Validates the inner form
-	 */
-	public validate(): ValidationErrors | null {
-		// Iben: If the form itself is invalid, we return the invalidForm: true right away
-		if (this.form.invalid) {
-			return { invalidForm: true };
-		}
-
-		// Iben: In case the form is invalid, we check if the child controls are possibly invalid
-		return hasErrors(this.form) ? { invalidForm: true } : null;
-	}
-
-	public ngOnDestroy(): void {
-		this.destroy$.next(undefined);
-		this.destroy$.complete();
 	}
 
 	/**

--- a/libs/forms/src/lib/abstracts/form-accessor-container/form-accessor-container.ts
+++ b/libs/forms/src/lib/abstracts/form-accessor-container/form-accessor-container.ts
@@ -25,6 +25,8 @@ export class FormAccessorContainer implements OnDestroy {
 	protected readonly destroyed$ = new Subject();
 
 	/**
+	 * @deprecated This method should no longer be used, use the markAsDirty on the form itself instead
+	 *
 	 * Marks the form and all the inputs of every subsequent form-accessors as dirty
 	 *
 	 * @param  form - The form used in the component
@@ -37,6 +39,8 @@ export class FormAccessorContainer implements OnDestroy {
 	}
 
 	/**
+	 * @deprecated This method should no longer be used, use the markAsTouched on the form itself instead
+	 *
 	 * Marks the form and all the inputs of every subsequent form-accessors as touched
 	 *
 	 * @param  form - The form used in the component

--- a/libs/forms/src/lib/abstracts/form/form.accessor.spec.ts
+++ b/libs/forms/src/lib/abstracts/form/form.accessor.spec.ts
@@ -1,231 +1,122 @@
-import { ChangeDetectorRef, Component, forwardRef, Injector } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import {
-	ControlContainer,
-	FormControl,
-	FormGroup,
-	NG_VALUE_ACCESSOR,
-	ReactiveFormsModule,
-	Validators,
-} from '@angular/forms';
+import { ChangeDetectorRef, Component, Injector } from '@angular/core';
+import { FormControl, FormGroup, NgControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { FormAccessor } from './form.accessor';
+import { FormAccessor } from '../../abstracts';
+import { createAccessorProviders } from '../../utils';
+
+@Component({
+	selector: 'kp-form-accessor',
+	template: ``,
+	providers: [createAccessorProviders(FormAccessorComponent)],
+})
+export class FormAccessorComponent extends FormAccessor<any, any> {
+	initForm() {
+		return new FormGroup({
+			hello: new FormControl(null, [Validators.required, Validators.email]),
+			world: new FormControl(null, Validators.minLength(3)),
+		});
+	}
+}
 
 describe('FormAccessor', () => {
-	@Component({
-		selector: 'kp-forms-component',
-		template: '',
-		providers: [
-			{
-				provide: NG_VALUE_ACCESSOR,
-				useExisting: forwardRef(() => TestComponent),
-				multi: true,
-			},
-		],
-	})
-	class TestComponent extends FormAccessor<
-		{ name: string },
-		FormGroup<{ name: FormControl<string> }>
-	> {
-		constructor(cdRef: ChangeDetectorRef) {
-			super(cdRef);
-		}
-
-		initForm() {
-			return new FormGroup({
-				name: new FormControl('', Validators.required),
-			});
-		}
-	}
-
-	let fixture: ComponentFixture<TestComponent>;
-	let component: TestComponent;
+	let fixture: ComponentFixture<FormAccessorComponent>;
+	let component: FormAccessorComponent;
 
 	beforeEach(() => {
-		const testBed = TestBed.configureTestingModule({
-			declarations: [TestComponent],
+		TestBed.configureTestingModule({
+			declarations: [FormAccessorComponent],
 			imports: [ReactiveFormsModule],
-			providers: [ControlContainer],
+			providers: [ChangeDetectorRef, Injector, NgControl],
 		});
 
-		fixture = testBed.createComponent(TestComponent);
+		fixture = TestBed.createComponent(FormAccessorComponent);
 		component = fixture.componentInstance;
-		(component as any).onChange = jasmine.createSpy();
+
+		try {
+			fixture.detectChanges();
+		} catch (error) {}
 	});
 
-	describe('writeValue', () => {
-		it('should not call the `onChange` method when the writeValue is called', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
+	it('should mark the form as touched', () => {
+		component.markAsTouched();
 
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-			component.writeValue({ name: 'test' });
-
-			expect(component.form.value).toEqual({ name: 'test' });
-			expect((component as any).onChange).not.toHaveBeenCalled();
-		}));
+		expect(component.form.get('hello').touched).toBeTrue();
+		expect(component.form.get('world').touched).toBeTrue();
 	});
 
-	describe('setDisabledState', () => {
-		it('should not call the `onChange` method when setDisabledState is called', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
+	it('should mark the form as dirty', () => {
+		component.markAsDirty();
 
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.setDisabledState(false);
-
-			expect((component as any).onChange).not.toHaveBeenCalled();
-		}));
+		expect(component.form.get('hello').dirty).toBeTrue();
+		expect(component.form.get('world').dirty).toBeTrue();
 	});
 
-	describe('onChange', () => {
-		it('should call the `onChange` if the form gets changed', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
+	it('should mark the form as pristine', () => {
+		component.markAsPristine();
 
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.form.patchValue({ name: 'test' });
-
-			expect((component as any).onChange).toHaveBeenCalledWith({ name: 'test' });
-		}));
+		expect(component.form.get('hello').pristine).toBeTrue();
+		expect(component.form.get('world').pristine).toBeTrue();
 	});
 
-	describe('markAsTouched/markAsPristine', () => {
-		it('should set the form and its controls to touched when markAsTouched has been called', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
+	it('should disable the form', () => {
+		//Iben: Set this as the component is not rendered
+		component.skipInitialSetDisable = false;
+		component.setDisabledState(true);
 
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.markAsTouched();
-
-			expect(component.form.touched).toBe(true);
-			expect(component.form.get('name').touched).toBe(true);
-		}));
+		expect(component.form.disabled).toBeTrue();
+		expect(component.form.get('hello').disabled).toBeTrue();
+		expect(component.form.get('world').disabled).toBeTrue();
 	});
 
-	describe('validate', () => {
-		it('should call the `validate` method with the correct output when the form is valid', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.form.patchValue({ name: 'test' });
-
-			expect(component.validate()).toEqual(null);
-		}));
-
-		it('should call the `validate` method with the correct output when the form is invalid', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			expect(component.validate()).toEqual({ invalidForm: true });
-		}));
+	it('should validate the form', () => {
+		expect(component.validate()).toEqual({ invalidForm: true });
 	});
 });
 
-describe('FormAccessor with mappers', () => {
-	@Component({
-		selector: 'kp-forms-component',
-		template: '',
-		providers: [
-			{
-				provide: NG_VALUE_ACCESSOR,
-				useExisting: forwardRef(() => TestComponent),
-				multi: true,
-			},
-		],
-	})
-	class TestComponent extends FormAccessor<
-		string,
-		FormGroup<{ name: FormControl<string> }>,
-		{ name: string }
-	> {
-		constructor(injector: Injector, cdRef: ChangeDetectorRef) {
-			super(cdRef);
-		}
-
-		initForm() {
-			return new FormGroup({
-				name: new FormControl(''),
-			});
-		}
-
-		onWriteValueMapper(name: string) {
-			return { name };
-		}
-
-		onChangeMapper({ name }: { name: string }) {
-			return name;
-		}
+@Component({
+	selector: 'kp-test-form-accessor',
+	template: ``,
+	providers: [createAccessorProviders(FormAccessorComponent)],
+})
+export class TestComponent extends FormAccessor<string, FormControl<number>, number> {
+	initForm() {
+		return new FormControl<number>(null);
 	}
 
+	public onChangeMapper(value: number): string {
+		return `${value}`;
+	}
+
+	public onWriteValueMapper(value: string): number {
+		return parseInt(value);
+	}
+}
+
+describe('FormAccessor with mapper', () => {
 	let fixture: ComponentFixture<TestComponent>;
 	let component: TestComponent;
 
 	beforeEach(() => {
-		const testBed = TestBed.configureTestingModule({
+		TestBed.configureTestingModule({
 			declarations: [TestComponent],
 			imports: [ReactiveFormsModule],
-			providers: [ControlContainer],
+			providers: [ChangeDetectorRef, Injector, NgControl],
 		});
 
-		fixture = testBed.createComponent(TestComponent);
+		fixture = TestBed.createComponent(TestComponent);
 		component = fixture.componentInstance;
-		(component as any).onChange = jasmine.createSpy();
+
+		try {
+			fixture.detectChanges();
+		} catch (error) {}
 	});
 
-	describe('writeValue', () => {
-		it('should set the form with the mapped value', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-			component.writeValue('test');
-
-			expect(component.form.value).toEqual({ name: 'test' });
-		}));
+	it('should map the value when written', () => {
+		expect(component.onWriteValueMapper('5')).toEqual(5);
 	});
 
-	describe('onChange', () => {
-		it('should call the `onChange` with the mapped value', fakeAsync(async () => {
-			// Flush the component `setTimeout`
-			tick();
-
-			fixture.detectChanges();
-
-			// Wait until the task queue becomes empty
-			await fixture.whenStable();
-
-			component.form.patchValue({ name: 'test' });
-
-			expect((component as any).onChange).toHaveBeenCalledWith('test');
-		}));
+	it('should map the value when changed', () => {
+		expect(component.onChangeMapper(5)).toEqual('5');
 	});
 });

--- a/libs/forms/src/lib/abstracts/form/form.accessor.ts
+++ b/libs/forms/src/lib/abstracts/form/form.accessor.ts
@@ -1,265 +1,22 @@
-import {
-	ChangeDetectorRef,
-	Directive,
-	Input,
-	OnDestroy,
-	OnInit,
-	Output,
-	QueryList,
-	ViewChildren,
-} from '@angular/core';
-import {
-	ValidationErrors,
-	ControlValueAccessor,
-	AbstractControl,
-	FormControl,
-} from '@angular/forms';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { filter, takeUntil, tap } from 'rxjs/operators';
+import { Directive, OnInit } from '@angular/core';
+import { AbstractControl, FormControl } from '@angular/forms';
+import { takeUntil, tap } from 'rxjs/operators';
 
-import { BaseFormAccessor } from '../base-form/base-form.accessor';
-import { DataFormAccessor } from '../data-form/data-form.accessor';
-import { FormAccessorControlsEntity, FormStateOptionsEntity } from '../../interfaces';
-import {
-	handleFormAccessorControlDisabling,
-	handleFormAccessorMarkAsTouched,
-	handleFormAccessorMarkAsDirty,
-	hasErrors,
-	handleFormAccessorUpdateValueAndValidity,
-} from '../../utils';
+import { NgxFormsControlValueAccessor } from '../custom-control-value-accessor';
 
 @Directive()
 export abstract class FormAccessor<
-	DataType = unknown,
-	FormAccessorFormType extends AbstractControl = FormControl,
-	FormValueType = DataType
-> implements ControlValueAccessor, OnInit, OnDestroy
+		DataType = unknown,
+		FormAccessorFormType extends AbstractControl = FormControl,
+		FormValueType = DataType
+	>
+	extends NgxFormsControlValueAccessor<DataType, FormAccessorFormType, FormValueType>
+	implements OnInit
 {
-	/**
-	 * A list of all DataFormAccessors en FormAccessors of this component
-	 */
-	@ViewChildren(BaseFormAccessor) accessors: QueryList<DataFormAccessor | FormAccessor>;
-
-	/**
-	 * Whether the first setDisable has run
-	 */
-	private initialSetDisableHasRun: boolean = false;
-
-	// On destroy flow handler
-	protected readonly destroy$ = new Subject();
-
-	// Subject to check whether the form is initialized
-	protected readonly initializedSubject$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
-		false
-	);
-
-	/**
-	 * Stream to know whether the form has been initialized
-	 */
-	@Output()
-	public readonly initialized$: Observable<boolean> = this.initializedSubject$.asObservable();
-
-	/**
-	 * Inner form to write to
-	 */
-	public form: FormAccessorFormType;
-
-	/**
-	 * Keys of the fields we wish to disable.
-	 * By default this will emit a valueChanges, this can be overwritten by the emitValueWhenDisableFieldsUsingInput in the Accessor
-	 *
-	 * @memberof FormAccessor
-	 */
-	@Input() set disableFields(keys: FormAccessorControlsEntity<FormAccessorFormType>[]) {
-		// Iben: Early exit in case the keys are not provided
-		if (!keys) {
-			return;
-		}
-
-		// Iben: Setup a subject to track whether we're still disabling the fields
-		const disabling = new Subject();
-
-		// Iben: Add the keys to a set for more performant lookup and convert those to a string to not have Typescript issues later down the line
-		const controlKeys = new Set(keys);
-
-		// Iben: Check if we need to dispatch the disable or enable event
-		const emitEvent = this.emitValueWhenDisableFieldsUsingInput
-			? this.emitValueWhenDisableFieldsUsingInput(keys)
-			: true;
-
-		// Iben: Listen to the initialized state of the form
-		this.initialized$
-			.pipe(
-				filter(Boolean),
-				tap(() => {
-					// TODO: Iben: Remove this setTimeout once we're in a Signal based component
-					setTimeout(() => {
-						// Iben: Handle the disabling of the fields
-						handleFormAccessorControlDisabling(this.form, controlKeys, emitEvent);
-					});
-
-					// Iben: Set the disabling subject so that we can complete this subscription
-					disabling.next(undefined);
-					disabling.complete();
-				}),
-				takeUntil(disabling)
-			)
-			.subscribe();
-	}
-
-	/**
-	 * Whether we want to skip the first setDisable (https://github.com/angular/angular/pull/47576).
-	 * By default, this is true
-	 */
-	@Input() public skipInitialSetDisable: boolean = true;
-
 	/**
 	 * Method to set up the inner form
 	 */
 	abstract initForm(): FormAccessorFormType;
-
-	/**
-	 * Optional method to map the inner form value to an outer form specific format
-	 *
-	 * @param value - Value from the form
-	 */
-	public onChangeMapper?(value: Partial<FormValueType>): DataType;
-
-	/**
-	 * Optional method to map the outer form value to an inner form specific format
-	 *
-	 * @param value - Value from the form
-	 */
-	public onWriteValueMapper?(value: DataType): FormValueType;
-
-	/**
-	 * Whether or not we want to emit a value when we use the disableFields, by default this will emit
-	 *
-	 * @param  keys - Keys we're about to disable
-	 */
-	protected emitValueWhenDisableFieldsUsingInput?(
-		keys: FormAccessorControlsEntity<FormAccessorFormType>[]
-	): boolean;
-
-	constructor(readonly cdRef: ChangeDetectorRef) {}
-
-	/**
-	 * Marks the control attached to this accessor as touched
-	 */
-	public onTouch: Function = () => {}; // tslint:disable-line:no-empty
-	private onChange: Function = (_: any) => {}; // tslint:disable-line:no-empty
-
-	public registerOnChange(fn: any): void {
-		this.onChange = fn;
-	}
-
-	public registerOnTouched(fn: any): void {
-		this.onTouch = fn;
-	}
-
-	/**
-	 * Writes value to the inner form
-	 *
-	 * @param value - Value to patch in the inner form
-	 */
-	public writeValue(value: DataType | undefined | null): void {
-		// Iben: Early exit in case the form was not found
-		if (!this.form) {
-			console.error(
-				'NgxForms: No form was found when trying to write a value. This error can occur when overwriting the ngOnInit without invoking super.OnInit().'
-			);
-
-			return;
-		}
-
-		// Iben: Reset the current form without emitEvent to not trigger the valueChanges
-		this.form.reset(undefined, { emitEvent: false });
-
-		// Iben: Patch the current form with the new value without emitEvent to not trigger the valueChanges
-		if (value !== undefined && value !== null) {
-			this.form.patchValue(this.onWriteValueMapper ? this.onWriteValueMapper(value) : value, {
-				emitEvent: false,
-			});
-		}
-
-		// Iben: Validate the current value
-		this.validate();
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Mark all controls of the form as touched
-	 */
-	public markAsTouched(options: FormStateOptionsEntity = {}): void {
-		handleFormAccessorMarkAsTouched(this.form, this.accessors?.toArray() || [], options);
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Mark all controls of the form as dirty
-	 */
-	public markAsDirty(options: FormStateOptionsEntity): void {
-		handleFormAccessorMarkAsDirty(this.form, this.accessors?.toArray() || [], options);
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Update the value and validity of the provided form
-	 */
-	public updateAllValueAndValidity(options: FormStateOptionsEntity): void {
-		handleFormAccessorUpdateValueAndValidity(
-			this.form,
-			this.accessors?.toArray() || [],
-			options
-		);
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Disables/enables the inner form based on the passed value
-	 *
-	 * @param isDisabled - Whether or not the form should be disabled
-	 */
-	public setDisabledState(isDisabled: boolean) {
-		// Iben: Skip the initial setDisabled, as this messes up our form approach.
-		// https://github.com/angular/angular/pull/47576
-		if (this.skipInitialSetDisable && !this.initialSetDisableHasRun) {
-			this.initialSetDisableHasRun = true;
-
-			return;
-		}
-
-		// Iben: Disable or enable the form based on the provided state. Do not emit a change to avoid valueChanges
-		if (isDisabled) {
-			this.form.disable({ emitEvent: false });
-		} else {
-			this.form.enable({ emitEvent: false });
-		}
-
-		// Iben: Detect changes so the changes are visible in the dom
-		this.cdRef.detectChanges();
-	}
-
-	/**
-	 * Validates the inner form
-	 */
-	public validate(): ValidationErrors | null {
-		// Iben: If the form itself is invalid, we return the invalidForm: true right away
-		if (this.form.invalid) {
-			return { invalidForm: true };
-		}
-
-		// Iben: In case the form is invalid, we check if the child controls are possibly invalid
-		return hasErrors(this.form) ? { invalidForm: true } : null;
-	}
 
 	public ngOnInit(): void {
 		// Iben: Set the inner form
@@ -287,10 +44,5 @@ export abstract class FormAccessor<
 				takeUntil(this.destroy$)
 			)
 			.subscribe();
-	}
-
-	public ngOnDestroy(): void {
-		this.destroy$.next(undefined);
-		this.destroy$.complete();
 	}
 }

--- a/libs/forms/src/lib/directives/errors/errors.directive.spec.ts
+++ b/libs/forms/src/lib/directives/errors/errors.directive.spec.ts
@@ -1,9 +1,10 @@
-import { Component, forwardRef } from '@angular/core';
+import { ChangeDetectorRef, Component, Injector, forwardRef } from '@angular/core';
 import {
 	FormControl,
 	FormGroup,
 	NG_VALIDATORS,
 	NG_VALUE_ACCESSOR,
+	NgControl,
 	ReactiveFormsModule,
 	Validators,
 } from '@angular/forms';
@@ -68,6 +69,7 @@ describe('NgxFormsErrorsDirective', () => {
 					ReactiveFormsModule,
 					NgxFormsErrorsModule.forRoot({ showWhen: 'dirty', errors }),
 				],
+				providers: [ChangeDetectorRef, Injector, NgControl],
 			});
 
 			fixture = TestBed.createComponent(FormAccessorComponent);
@@ -119,6 +121,7 @@ describe('NgxFormsErrorsDirective', () => {
 						component: FormErrorComponent,
 					}),
 				],
+				providers: [ChangeDetectorRef, Injector, NgControl],
 			});
 
 			fixture = TestBed.createComponent(FormAccessorComponent);

--- a/libs/forms/src/lib/utils/form-accessor/form-accessor.utils.ts
+++ b/libs/forms/src/lib/utils/form-accessor/form-accessor.utils.ts
@@ -151,6 +151,25 @@ export const handleFormAccessorMarkAsTouched = (
 };
 
 /**
+ * Marks a form and all the form-accessors this form is based on as pristine
+ *
+ * @param form - The form we wish to mark as pristine
+ * @param accessors - An array of all the accessors we wish to mark as pristine
+ * @param options - Form state options we wish to provide
+ */
+export const handleFormAccessorMarkAsPristine = (
+	form: AbstractControl,
+	accessors: (FormAccessor | DataFormAccessor)[],
+	options: FormStateOptionsEntity = {}
+) => {
+	// Iben: Mark all the controls and the children as touched
+	form.markAsPristine();
+
+	// Iben: Loop over each form accessor and call the mark as touched function, so all subsequent accessors are also marked as touched
+	accessors.forEach((accessor) => accessor.markAsPristine(options));
+};
+
+/**
  * Updates a form and all the form-accessors this form i
  *
  * @param form - The form we wish to update the value and validity of


### PR DESCRIPTION
The previous implementation for the markAsTouched, markAsPristine and markAsDirty using the FormContainer approach had several downsides. 

- A FormContainer implementation was needed or it did not work
- Setting an individual control to touched/dirty/pristine did not work

This PR fixes the issues that were present in the earlier implementation, deprecates the older implementations, optimizes the code and streamlines the tests.

Due to the lack of a `updated` property in the `updateValueAndValidity`, there unfortunately is not a similar solution we can apply to this method and therefor we're still stuck with the current implementation.