### PR TITLE
feat(ngx-tour): Add extra properties to step and make clipPath function with window resize

### DIFF
--- a/apps/layout-test/src/pages/main/main.component.ts
+++ b/apps/layout-test/src/pages/main/main.component.ts
@@ -78,6 +78,7 @@ export class MainComponent {
 						tourItem: 'start',
 						content: 'This is a test',
 						title: 'Hello world',
+						stepClass: 'hello-world',
 						beforeVisible: () => {
 							return of(undefined).pipe(
 								tap(() => console.log('Running this before step 1'))
@@ -102,6 +103,10 @@ export class MainComponent {
 						title: 'Hello world 1',
 					},
 					{
+						title: 'Navigating to the next page',
+						content: 'This is a test!',
+					},
+					{
 						tourItem: 'secondary',
 						content: 'Secondary',
 						title: 'Secondary',
@@ -114,6 +119,11 @@ export class MainComponent {
 						tourItem: 'async',
 						content: 'Async content',
 						title: 'Async',
+					},
+					{
+						tourItem: 'item',
+						content: 'Get the first repeated item',
+						title: 'Repeated item',
 					},
 					{
 						beforeVisible: () => {

--- a/apps/layout-test/src/pages/secondary/secondary.component.html
+++ b/apps/layout-test/src/pages/secondary/secondary.component.html
@@ -12,3 +12,22 @@
 		{{data$ | async}}
 	</p>
 }
+
+
+<ul>
+	<li tourItem="item">
+		Item 1
+	</li>
+	<li tourItem="item">
+		Item 2
+	</li>
+	<li tourItem="item">
+		Item 3
+	</li>
+	<li tourItem="item">
+		Item 4
+	</li>
+	<li tourItem="item">
+		Item 5
+	</li>
+</ul>

--- a/apps/layout-test/src/tour/special-tour.component.scss
+++ b/apps/layout-test/src/tour/special-tour.component.scss
@@ -1,7 +1,6 @@
 :host {
 	display: block;
 	padding: 10px;
-	margin-top: 25px;
 	background: blue;
 	color: white;
 }

--- a/apps/layout-test/src/tour/tour.component.scss
+++ b/apps/layout-test/src/tour/tour.component.scss
@@ -1,6 +1,5 @@
 :host {
 	display: block;
 	padding: 10px;
-	margin-top: 25px;
 	background: white;
 }

--- a/libs/tour/README.md
+++ b/libs/tour/README.md
@@ -117,13 +117,19 @@ this.tourService.startTour([{
     ).subscribe()
 ```
 
-Individual steps in the tour can be further customized by either disabling the backdrop or providing a custom component to deviate from the default component. This can be done by using the `disableBackdrop` and the `component` property respectively. If you wish to provide extra data to the component outside of the 
-of the mandatory title and content, you can do so by providing it using the `data` property.
+Individual steps in the tour can be further customized with several properties, `component`, `disableBackdrop`, `data` and `stepClass`.
+
+First of, we can override the default component with a custom one using the `component` property. This is useful in use-cases where we want to have a step look completely different from the default step, like for instance an introduction step.
+
+Using `disableBackdrop` and `stepClass` we can have even more visual control over the step, by either disabling the backdrop or attaching a custom class to the step using the properties respectively.
+
+Finally, we can pass extra data to a step by using the `data` property. This allows for full customizability beyond the default title and content properties.
 
 ```ts
 this.tourService.startTour([{
     title: 'Hello', 
     content: 'World', 
+    stepClass: 'this-is-my-custom-class',
     component: SpecialIntroductionStepComponent,
     disableBackdrop: true,
     data: {userName: 'Mark'}
@@ -154,13 +160,19 @@ When an item is highlighted, the item also gets the `ngx-tour-item-active` class
 
 ### NgxTourStepComponent
 
-The `NgxTourStepComponent` presents us with 5 Inputs and one Output we need to handle the tours. By default, the two most important Inputs are `title` and `content`, which correspond with the two data properties we passed in the step. Additionally, the amount of steps in the tour and the current index of the step can be visualized using `amountOfSteps` and `currentIndex`. To maximize customisability, we can also pass a `data` property to the component. This data can be anything, and can be used to enrich a step.
+The `NgxTourStepComponent` presents us with 7 Inputs and one Output we need to handle the tours. 
+
+By default, the two most important Inputs are `title` and `content`, which correspond with the two data properties we passed in the step. Additionally, the amount of steps in the tour and the current index of the step can be visualized using `amountOfSteps` and `currentIndex`. To maximize customisability, we can also pass a `data` property to the component. This data can be anything, and can be used to enrich a step.
+
+The `position` and `stepClass` inputs are used to automatically set classes to the tour step, but can still be used freely. By default, the tour step component always gets the `ngx-tour-step` class, depending on its position it will also have a corresponding `ngx-tour-step-position-left|right|below|above` class. The step class will be set automatically as well.
 
 In order to navigate through the tour and close it when needed, the component has an Output called `handleInteraction` that takes three possible states, being `next`, `back` and `close`. Each of these interactions will continue the tour, go back in the tour or close the tour respectively.
 
 ## Known issues
 
-When the tour requires routing between multiple pages, we suggest including a `onClose` function that routes back to the original page when the tour closes. This ensures that the tour will go back to the initial page, regardless of where the user decides to close the tour. It should be noted though, that this can sometimes cause issues with the changeDetection, of which we currently don't have an in-package solution. The current fix is to run the change detection manually after the routing, which can be done in the `onClose` function.
+When the tour requires routing between multiple pages, we suggest including an `onClose` function that routes back to the original page when the tour closes. This ensures that the tour will go back to the initial page, regardless of where the user decides to close the tour. 
+
+It should be noted though, that this can sometimes cause issues with the changeDetection, of which we currently don't have an in-package solution. The current fix is to run the change detection manually after the routing, which can be done in the `onClose` function.
 
 ```ts
 this.tourService.startTour(

--- a/libs/tour/src/lib/abstracts/tour-step/tour-step.component.ts
+++ b/libs/tour/src/lib/abstracts/tour-step/tour-step.component.ts
@@ -1,39 +1,63 @@
-import { Directive, EventEmitter, Input, Output } from '@angular/core';
-import { NgxTourInteraction } from '../../types';
+import { Directive, EventEmitter, HostBinding, Input, OnInit, Output } from '@angular/core';
+import { NgxTourInteraction, NgxTourStepPosition } from '../../types';
 
 /**
  * An abstract class that defines the minimum properties needed for the step component to be rendered
  */
 @Directive()
-export abstract class NgxTourStepComponent<DataType = any> {
+export abstract class NgxTourStepComponent<DataType = any> implements OnInit {
+	/**
+	 * The ngx-tour-step class of the component
+	 */
+	@HostBinding('class') protected rootClass: string;
+
+	/**
+	 * The position of the step
+	 */
+	@Input({
+		required: true,
+	})
+	public position: NgxTourStepPosition | undefined;
+
 	/**
 	 * The title of the step
 	 */
-	@Input({ required: true }) title: string;
+	@Input({ required: true }) public title: string;
 
 	/**
 	 * The content of the step
 	 */
-	@Input({ required: true }) content: string;
+	@Input({ required: true }) public content: string;
 
 	/**
 	 * The index of the step
 	 */
-	@Input({ required: true }) currentStep: number;
+	@Input({ required: true }) public currentStep: number;
 
 	/**
 	 * The total amount of steps
 	 */
-	@Input({ required: true }) amountOfSteps: number;
+	@Input({ required: true }) public amountOfSteps: number;
 
 	/**
 	 * Optional data we wish to use in a step
 	 */
-	@Input() data: DataType;
+	@Input() public data: DataType;
+
+	/**
+	 * A custom step class we can set
+	 */
+	@Input() public stepClass: string;
 
 	/**
 	 * Emits the possible interactions with a step
 	 */
-	@Output() handleInteraction: EventEmitter<NgxTourInteraction> =
+	@Output() public handleInteraction: EventEmitter<NgxTourInteraction> =
 		new EventEmitter<NgxTourInteraction>();
+
+	public ngOnInit(): void {
+		// Iben: We set the correct host class. As this step is rendered and not changed afterwards, we do not have to adjust this in the onChanges
+		const positionClass = this.position ? `ngx-tour-step-position-${this.position}` : '';
+		this.rootClass = `ngx-tour-step ${positionClass} ${this.stepClass || ''}`;
+	}
 }

--- a/libs/tour/src/lib/types/tour.types.ts
+++ b/libs/tour/src/lib/types/tour.types.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs';
 import { Type } from '@angular/core';
 import { NavigationExtras } from '@angular/router';
 import { NgxTourStepComponent } from '../abstracts';
+import { NgxTourItemDirective } from '../directives';
 
 export type NgxTourDirection = 'next' | 'back';
 
@@ -9,12 +10,24 @@ export type NgxTourInteraction = NgxTourDirection | 'close';
 
 export type NgxTourStepPosition = 'above' | 'below' | 'right' | 'left';
 
+export type NgxTourRegistrationEvent = {
+	tourItem: string;
+	element?: NgxTourItemDirective;
+	type: 'register' | 'unregister';
+};
+
 export interface NgxTourRouteOptions {
 	route: string[];
 	extras: NavigationExtras;
 }
+export interface NgxTourBackdropClipEvent {
+	backdrop: HTMLElement;
+	cutoutMargin: number;
+	item?: HTMLElement;
+}
 
 export type NgxTourAction = (step: NgxTourStep, index: number) => void | Observable<unknown>;
+
 export interface NgxTourStep<DataType = any> {
 	/**
 	 * The title we wish to display on the step
@@ -75,4 +88,9 @@ export interface NgxTourStep<DataType = any> {
 	 * An optional margin we can set for the cutout around an element. By default, this is set to 5px
 	 */
 	cutoutMargin?: number;
+
+	/**
+	 * An optional class we can attach to the step
+	 */
+	stepClass?: string;
 }


### PR DESCRIPTION
Adds the following items:

- Now the clipPath of the backdrop works with window resizing, so the highlight will not stop working.
- Registering elements now works with events, so that the elements record gets updated correctly (and registers the first element when multiple items have the same tourItem tag)
- Extra data has been added to the tour step for further customization.
- The step now takes the cutout margin into account when rendering, so it does not overlap.