### PR TITLE
fix(ngx-tour): Fix issue with inconsistent scroll behaviour and prevent issues with missing the currentStep

### DIFF
--- a/libs/tour/src/lib/services/tour-service/tour.service.ts
+++ b/libs/tour/src/lib/services/tour-service/tour.service.ts
@@ -333,6 +333,11 @@ export class NgxTourService implements OnDestroy {
 			this.overlayRef = undefined;
 		}
 
+		// Iben: Early exit if there's no current step
+		if (!currentStep) {
+			return of('close');
+		}
+
 		// Iben: Get the previous step, if it exists
 		const previousStep = this.currentStepSubject.getValue();
 		const previousItem = this.elements[previousStep?.tourItem]?.getValue();
@@ -417,8 +422,11 @@ export class NgxTourService implements OnDestroy {
 		this.previousStepSubject.next(this.currentStepSubject.getValue());
 		this.currentStepSubject.next(currentStep);
 
-		// Iben: Scroll item into view if it's not in view
 		this.runInBrowser(() => {
+			// Iben: Scroll to the top before each step to get consistent behavior when going back and forth
+			window.scrollTo({ top: 0 });
+
+			// Iben: Scroll to the element if it's not in view
 			if (item && !elementIsVisibleInViewport(item.elementRef.nativeElement)) {
 				item.elementRef.nativeElement.scrollIntoView();
 			}


### PR DESCRIPTION
- Prevents the tour from crashing if there for some reason isn't a current step
- Always scroll back to the top before each step so that when we move back and forth during the tour, the look and feel is consistent.