### PR TITLE
fix(ngx-tour): emit the closing events when the last element is not found

### DIFF
--- a/apps/layout-test/src/pages/main/main.component.ts
+++ b/apps/layout-test/src/pages/main/main.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component } from '@angular/core';
 
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { from, of, tap } from 'rxjs';
+import { from, map, of, tap } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { SpecialTourItemComponent } from '../../tour/special-tour.component';
 import {
@@ -52,6 +52,13 @@ export class MainComponent {
 			],
 			[{ key: 'b', isActive: true }],
 		]);
+
+		this.tourService.currentTour$
+			.pipe(
+				map((tour) => Boolean(tour)),
+				tap((isTourActive) => console.log('Tour active:', isTourActive))
+			)
+			.subscribe();
 	}
 
 	drop(event: NgxConfigurableLayoutItemDropEvent): boolean {

--- a/libs/tour/README.md
+++ b/libs/tour/README.md
@@ -170,6 +170,8 @@ In order to navigate through the tour and close it when needed, the component ha
 
 ## Known issues
 
+### Navigation
+
 When the tour requires routing between multiple pages, we suggest including an `onClose` function that routes back to the original page when the tour closes. This ensures that the tour will go back to the initial page, regardless of where the user decides to close the tour. 
 
 It should be noted though, that this can sometimes cause issues with the changeDetection, of which we currently don't have an in-package solution. The current fix is to run the change detection manually after the routing, which can be done in the `onClose` function.
@@ -186,3 +188,9 @@ this.tourService.startTour(
 			}
 )
 ```
+
+### Auto scroll
+
+The `NgxTourService` will always try to make sure the active element is visible. For this, we use the [scrollIntoView()](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) method. It is possible that this will fail in case the previous element is not found.
+
+A solution would be to implement a custom scrolling method to scroll the viewport until the desired element is centered.

--- a/libs/tour/src/lib/services/tour-service/tour.service.ts
+++ b/libs/tour/src/lib/services/tour-service/tour.service.ts
@@ -344,9 +344,9 @@ export class NgxTourService implements OnDestroy {
 			this.overlayRef = undefined;
 		}
 
-		// Iben: Early exit if there's no current step
+		// Iben: Early exit and close tour if there's no current step
 		if (!currentStep) {
-			return of('close');
+			return this.closeTour();
 		}
 
 		// Iben: Get the previous step, if it exists


### PR DESCRIPTION
This fix will prevent the issue of the tourState being persistent when the tour closes before a manual closing trigger.