### PR TITLE
feat(ngx-tour): Adds an operator to mock data when the tour is active, adds a delay and improves visuals

### DIFF
--- a/apps/layout-test/src/pages/main/main.component.html
+++ b/apps/layout-test/src/pages/main/main.component.html
@@ -3,7 +3,7 @@
 </h1>
 
 <button (click)="startTour()">
-	Start the tour!
+	{{dataString$ | async}}
 </button>
 
 <h1 tourItem="start">NgxDisplayContent</h1>

--- a/apps/layout-test/src/pages/main/main.component.ts
+++ b/apps/layout-test/src/pages/main/main.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectorRef, Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { from, map, of, tap } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
 import { SpecialTourItemComponent } from '../../tour/special-tour.component';
 import {
 	NgxConfigurableLayoutComponent,
@@ -11,7 +12,7 @@ import {
 	NgxConfigurableLayoutItemDropEvent,
 	NgxDisplayContentDirective,
 } from '@ngx/layout';
-import { NgxTourItemDirective, NgxTourService } from '@ngx/tour';
+import { NgxTourItemDirective, NgxTourService, useMockDataDuringTour } from '@ngx/tour';
 
 @Component({
 	selector: 'main',
@@ -24,6 +25,7 @@ import { NgxTourItemDirective, NgxTourService } from '@ngx/tour';
 		ReactiveFormsModule,
 		NgxDisplayContentDirective,
 		NgxTourItemDirective,
+		CommonModule,
 	],
 })
 export class MainComponent {
@@ -35,6 +37,10 @@ export class MainComponent {
 		offline: new FormControl<boolean>(false),
 		error: new FormControl<boolean>(false),
 	});
+
+	public dataString$ = of('Start the tour!').pipe(
+		useMockDataDuringTour<string>('The tour is running!')
+	);
 
 	constructor(
 		private readonly tourService: NgxTourService,

--- a/libs/tour/README.md
+++ b/libs/tour/README.md
@@ -168,6 +168,20 @@ The `position` and `stepClass` inputs are used to automatically set classes to t
 
 In order to navigate through the tour and close it when needed, the component has an Output called `handleInteraction` that takes three possible states, being `next`, `back` and `close`. Each of these interactions will continue the tour, go back in the tour or close the tour respectively.
 
+### useMockDataDuringTour
+
+During a tour, we might want to show different data in our views, to ensure that everything fits just right for the tour. We can use the `useMockDataDuringTour` operator to do so! Provide mock data to the operator, and depending on whether the tour is active, the correct data will be shown.
+
+```ts
+...
+
+public readonly label$: Observable<string> = this.dataService.label$.pipe(
+    useMockDataDuringTour('This is a mock!')
+)
+```
+
+This operator only works within an injection context, and therefor cannot be used in methods or outside of the constructor.
+
 ## Known issues
 
 ### Navigation

--- a/libs/tour/src/index.ts
+++ b/libs/tour/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/directives';
 export * from './lib/services';
 export * from './lib/types';
 export * from './lib/providers';
+export * from './lib/operators';

--- a/libs/tour/src/lib/mocks/index.ts
+++ b/libs/tour/src/lib/mocks/index.ts
@@ -1,0 +1,3 @@
+export * from './tour-step.component.mock';
+export * from './overlay.mock';
+export * from './tour-holder.component.mock';

--- a/libs/tour/src/lib/mocks/overlay.mock.ts
+++ b/libs/tour/src/lib/mocks/overlay.mock.ts
@@ -1,0 +1,8 @@
+// Iben: This mock provides an implementation to the CDK Overlay
+export const OverlayMock: any = {
+	position: jest.fn(),
+	scrollStrategies: {
+		block: jest.fn(),
+	},
+	create: jest.fn(),
+};

--- a/libs/tour/src/lib/mocks/tour-holder.component.mock.ts
+++ b/libs/tour/src/lib/mocks/tour-holder.component.mock.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { useMockDataDuringTour } from '../operators';
+import { NgxTourService } from '../services';
+
+// Iben: This mock tour holder is used in the test to test the useMockDataDuringTour operator
+@Component({
+	selector: 'mock-tour-holder',
+	template: '',
+	standalone: true,
+})
+export class MockTourHolderComponent {
+	private readonly dataSourceSubject = new BehaviorSubject('Hello world!');
+
+	public readonly data$ = this.dataSourceSubject
+		.asObservable()
+		.pipe(useMockDataDuringTour('World hello!'));
+
+	constructor(private readonly tourService: NgxTourService) {}
+
+	public startTour() {
+		this.tourService.startTour([{ title: 'Mock', content: 'Mock' }]).subscribe();
+	}
+}

--- a/libs/tour/src/lib/mocks/tour-step.component.mock.ts
+++ b/libs/tour/src/lib/mocks/tour-step.component.mock.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { NgxTourStepComponent } from '../abstracts';
+
+// Iben: This mock tour step component can be used where needed
+@Component({
+	selector: 'mock-tour-step-component',
+	template: '',
+	standalone: true,
+})
+export class MockTourStepComponent extends NgxTourStepComponent {}

--- a/libs/tour/src/lib/operators/index.ts
+++ b/libs/tour/src/lib/operators/index.ts
@@ -1,0 +1,1 @@
+export * from './use-mock-data-during-tour/use-mock-data-during-tour.operator';

--- a/libs/tour/src/lib/operators/use-mock-data-during-tour/use-mock-data-during-tour.operator.spec.ts
+++ b/libs/tour/src/lib/operators/use-mock-data-during-tour/use-mock-data-during-tour.operator.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { subscribeSpyTo } from '@hirez_io/observer-spy';
+
+import { PLATFORM_ID } from '@angular/core';
+import { provideNgxTourConfiguration } from '../../providers';
+import { MockTourHolderComponent, MockTourStepComponent } from '../../mocks';
+
+describe('useMockDataDuringTour', () => {
+	let fixture: ComponentFixture<MockTourHolderComponent>;
+	let component: MockTourHolderComponent;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [MockTourHolderComponent],
+			providers: [
+				provideNgxTourConfiguration(MockTourStepComponent),
+				{ provide: PLATFORM_ID, useValue: 'server' },
+			],
+		});
+
+		fixture = TestBed.createComponent(MockTourHolderComponent);
+		component = fixture.componentInstance;
+	});
+
+	it('should give the actual data if the tour is not active', () => {
+		TestBed.runInInjectionContext(() => {
+			expect(subscribeSpyTo(component.data$).getLastValue()).toEqual('Hello world!');
+		});
+	});
+
+	it('should give the mock data when the tour is active', () => {
+		TestBed.runInInjectionContext(() => {
+			component.startTour();
+
+			expect(subscribeSpyTo(component.data$).getLastValue()).toEqual('World hello!');
+		});
+	});
+});

--- a/libs/tour/src/lib/operators/use-mock-data-during-tour/use-mock-data-during-tour.operator.ts
+++ b/libs/tour/src/lib/operators/use-mock-data-during-tour/use-mock-data-during-tour.operator.ts
@@ -1,0 +1,32 @@
+import { inject } from '@angular/core';
+import { OperatorFunction, combineLatest, map, of, switchMap } from 'rxjs';
+
+import { NgxTourService } from '../../services';
+
+/**
+ * An operator to map the data of an Observable to mock data when the NgxTourService has an active tour.
+ *
+ * *Important*: This operator only works within an injection context
+ *
+ * @param mockData - The mock data we wish to use when the tour is active
+ */
+export const useMockDataDuringTour = <ValueType>(
+	mockData: ValueType
+): OperatorFunction<ValueType, ValueType> => {
+	// Iben: Inject the tour service
+	const tourService: NgxTourService = inject(NgxTourService);
+
+	// Iben: Listen to the active state of the tour
+	return switchMap((value: ValueType) => {
+		return combineLatest([of(value), tourService.tourActive$]).pipe(
+			map(([value, isActive]) => {
+				// Iben: If the tour is active, return the mockData, else, return the value
+				if (isActive) {
+					return mockData;
+				}
+
+				return value;
+			})
+		);
+	});
+};

--- a/libs/tour/src/lib/services/tour-service/tour.service.spec.ts
+++ b/libs/tour/src/lib/services/tour-service/tour.service.spec.ts
@@ -1,30 +1,15 @@
-import { Component } from '@angular/core';
 import { subscribeSpyTo } from '@hirez_io/observer-spy';
 
-import { NgxTourStepComponent } from '../../abstracts';
+import { MockTourStepComponent, OverlayMock } from '../../mocks';
 import { NgxTourService } from './tour.service';
 
 //TODO: Iben: Add Cypress tests so we can test the actual flow and the remaining methods
 
-@Component({
-	standalone: true,
-	template: '',
-})
-class TestStepComponent extends NgxTourStepComponent {}
-
 describe('NgxTourService', () => {
 	let service: NgxTourService;
 
-	const overlay: any = {
-		position: jest.fn(),
-		scrollStrategies: {
-			block: jest.fn(),
-		},
-		create: jest.fn(),
-	};
-
 	beforeEach(() => {
-		service = new NgxTourService(overlay, 'server', TestStepComponent);
+		service = new NgxTourService(OverlayMock, 'server', MockTourStepComponent);
 	});
 
 	it('should emit when the tour has started', () => {


### PR DESCRIPTION
This PR adds:

1.  An operator to show mock data when the tour is active
2. A slight delay before the tour starts to ensure that change detection has run
3. A visual update so the backdrop gets updated instead of deleted and recreated