### PR TITLE
fix(ngx-tour): make sure the startTour emits when the tour ends

### DIFF
--- a/apps/layout-test/src/pages/main/main.component.ts
+++ b/apps/layout-test/src/pages/main/main.component.ts
@@ -157,9 +157,17 @@ export class MainComponent {
 					return from(this.router.navigate([''])).pipe(
 						tap(() => {
 							this.cdRef.detectChanges();
+							console.log('This is the onClose callback');
 						})
 					);
 				}
+			)
+			.pipe(
+				tap(() => {
+					console.log(
+						'The tour has ended and all is reverted to their original state. This is ran at the very last.'
+					);
+				})
 			)
 			.subscribe();
 	}


### PR DESCRIPTION
# Explanation
The `startTour` method did not emit when the tour had ended. This makes sure the `tourEnded` subject emits `Observable(undefined)` when the tour is aborted or finished.

# Screenrecording
https://github.com/studiohyperdrive/ngx-tools/assets/56075460/01a35125-c081-4e17-a0ea-6031bebe648d