### PR TITLE
feat(ngx-layout): provide a service that allows subscribing to one or more media query

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,19 @@ This repo contains general usage libraries for shd Angular projects. Those libra
     -   This library provides a quick and easy template based table builder using the Angular CDK Table.
 
 -   i18n (`@studiohyperdrive/ngx-i18n`):
+
     -   This library provides a lazy-loaded modular approach to translations.
 
 -   cookies (`@studiohyperdrive/ngx-cookies`):
+
     -   This library provides a quick and easy wrapper for [CookieConsent V3](https://cookieconsent.orestbida.com).
 
 -   layout (`@studiohyperdrive/ngx-layout`):
-    -   `ngx-layout` is a collection of Angular components related to layout.
+
+    -   This library is a collection of Angular components related to layout.
+
+-   tour (`@studiohyperdrive/ngx-tour`):
+    -   This library provides the tools to build a guided walkthrough of one or more pages.
 
 You can find detailed explanations in their respective README’s.
 
@@ -72,7 +78,7 @@ You can find detailed explanations in their respective README’s.
 ### Add a new library
 
 To add a new library, consult the Angular CLI documentation:
-https://angular.io/guide/creating-libraries
+https://angular.dev/tools/libraries/creating-libraries
 
 After adding your library, make sure to check the karma set-up is consistent with other projects.  
 Check the following files:

--- a/apps/layout-test/src/app/app.component.ts
+++ b/apps/layout-test/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 import { RouterModule } from '@angular/router';
+import { NgxMediaQueryService } from '@ngx/utils';
 
 @Component({
 	selector: 'app-root',
@@ -8,4 +9,13 @@ import { RouterModule } from '@angular/router';
 	standalone: true,
 	imports: [RouterModule],
 })
-export class AppComponent {}
+export class AppComponent {
+	constructor(private readonly mediaService: NgxMediaQueryService) {
+		// Wouter: To see these in action, navigate to '/queries' in the browser
+		this.mediaService.registerMediaQueries(
+			['small', '(max-width: 500px)'],
+			['medium', '(max-width: 600px)'],
+			['large', '(max-width: 700px)']
+		);
+	}
+}

--- a/apps/layout-test/src/pages/mediaquery/mediaquery.component.ts
+++ b/apps/layout-test/src/pages/mediaquery/mediaquery.component.ts
@@ -1,0 +1,31 @@
+import { Component, OnInit } from '@angular/core';
+import { NgxMediaQueryService } from '@ngx/utils';
+
+@Component({
+	selector: 'mediaquery',
+	template: '<p>Scale this page to see the media query changes in the console.</p>',
+	standalone: true,
+})
+export class MediaQueryComponent implements OnInit {
+	constructor(private readonly mediaService: NgxMediaQueryService) {
+		// Uncomment below to view a duplicate query error
+		// this.mediaService.registerMediaQueries(['Yeet', '(max-width: 500px)']);
+		//
+		// Uncomment below to view a duplicate id warning
+		// this.mediaService.registerMediaQueries(['small', 'randomString']);
+	}
+
+	public ngOnInit() {
+		this.mediaService.getMatchingQuery$('small').subscribe((small) => {
+			console.log('Small: ', small);
+		});
+
+		this.mediaService.getMatchingQuery$('medium').subscribe((medium) => {
+			console.log('Medium: ', medium);
+		});
+
+		this.mediaService.getMatchingQuery$('large').subscribe((large) => {
+			console.log('Large: ', large);
+		});
+	}
+}

--- a/apps/layout-test/src/routes.ts
+++ b/apps/layout-test/src/routes.ts
@@ -11,4 +11,9 @@ export const routes: Routes = [
 		loadComponent: () =>
 			import('./pages/secondary/secondary.component').then((m) => m.SecondaryComponent),
 	},
+	{
+		path: 'queries',
+		loadComponent: () =>
+			import('./pages/mediaquery/mediaquery.component').then((m) => m.MediaQueryComponent),
+	},
 ];

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -181,6 +181,12 @@ This service provides a SSR proof Observable based approach to both the local- a
 
 [Full documentation.](src/lib/services/storage-service/storage.service.md)
 
+#### NgxMediaQueryService
+
+This service provides a SSR proof way to set and subscribe to the window's media query changes.
+
+[Full documentation.](src/lib/services/media-query/query.service.md)
+
 ### Abstracts
 
 #### NgxQueryParamFormSyncComponent

--- a/libs/utils/src/lib/services/index.ts
+++ b/libs/utils/src/lib/services/index.ts
@@ -3,3 +3,4 @@ export { windowMock, windowServiceMock } from './window-service/window.service.m
 
 export { SubscriptionService } from './subscription-service/subscription.service';
 export { NgxStorageService } from './storage-service/storage.service';
+export { NgxMediaQueryService } from './media-query/mediaquery.service';

--- a/libs/utils/src/lib/services/media-query/mediaquery.service.ts
+++ b/libs/utils/src/lib/services/media-query/mediaquery.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { filter, map, Observable, ReplaySubject } from 'rxjs';
+import { WindowService } from '../window-service/window.service';
+
+/**
+ * A service that can be used to track media queries and their changes. It exposes a method
+ * to register media queries, which takes an array of tuples with the id of the media query
+ * and the query itself. The service will then emit the id of the media query that has
+ * changed when subscribed to the `getMatchingQuery$` method.
+ */
+@Injectable({ providedIn: 'root' })
+export class NgxMediaQueryService implements OnDestroy {
+	/**
+	 * A map of media queries that are registered with the service.
+	 */
+	private readonly queryListMap: Map<string, MediaQueryList> = new Map();
+
+	/**
+	 * A map of the registered media queries with their id.
+	 */
+	private readonly queryIdMap: Map<string, string> = new Map();
+
+	/*
+	 * A map of listeners that are registered with the service.
+	 * They are saved to be able to remove them when the service is destroyed.
+	 */
+	private readonly mediaQueryListenerMap: Map<
+		string,
+		(queryChangedEvent: MediaQueryListEvent) => void
+	> = new Map();
+
+	/**
+	 * A subject that emits the id of the media query that has changed.
+	 */
+	private readonly queryChangedSubject: ReplaySubject<string> = new ReplaySubject();
+
+	constructor(private readonly windowService: WindowService) {}
+
+	/**
+	 * Register a list of media queries that need to be tracked by the service.
+	 *
+	 * @param queries - A list of media queries that should be registered with the service.
+	 */
+	public registerMediaQueries(...queries: [id: string, query: string][]): void {
+		this.windowService.runInBrowser(({ browserWindow }) => {
+			for (let [id, query] of queries) {
+				// Wouter: Warn if the id has already been registered.
+				if (this.queryIdMap.get(id)) {
+					return console.warn(
+						`NgxMediaQueryService: Media query with id '${id}' already exists and is defined by '${this.queryIdMap.get(
+							id
+						)}'`
+					);
+				}
+
+				// Wouter: If the query has already been registered, throw an error to prevent duplicate subscriptions
+				if ([...this.queryIdMap].some(([_, value]) => value === query)) {
+					const duplicateQuery = [...this.queryIdMap].find(
+						([_, value]) => value === query
+					);
+					throw new Error(
+						`NgxMediaQueryService: Query of ['${id}', ${query}] already exists and is defined by ['${duplicateQuery[0]}', ${duplicateQuery[1]}]`
+					);
+				}
+
+				// Wouter: save the id and query
+				this.queryIdMap.set(id, query);
+
+				// Wouter: For each query, create a MediaQueryList object
+				const matchedQuery = browserWindow.matchMedia(query);
+
+				// Wouter: Save the query
+				this.queryListMap.set(id, matchedQuery);
+
+				// Wouter: Emit the id of the query that has changed
+				this.queryChangedSubject.next(id);
+
+				// Wouter: Create a listener for the query. This is done separately to be
+				// able to remove the listener when the service is destroyed
+				const listener = (queryChangedEvent: MediaQueryListEvent) => {
+					this.queryListMap.set(id, queryChangedEvent.currentTarget as MediaQueryList);
+
+					// Wouter: Emit the id of the query that has changed
+					this.queryChangedSubject.next(id);
+				};
+
+				// Wouter: Register the listener to the query
+				matchedQuery.addEventListener('change', listener);
+
+				// Wouter: Save the listener
+				this.mediaQueryListenerMap.set(id, listener);
+			}
+		});
+	}
+
+	/**
+	 * Pass the id of the query whose changes need to be listened to.
+	 *
+	 * @param id - The id of the media query that should be checked.
+	 * @returns An observable that emits a boolean value whenever the requested media query changes.
+	 */
+	public getMatchingQuery$(id: string): Observable<boolean> {
+		// Wouter: Throw an error if the query has not been registered
+		if (!this.queryIdMap.has(id)) {
+			throw new Error(
+				`NgxMediaQueryService: No media query with id '${id}' has been registered. Please register the media query first using the 'registerMediaQueries' method.`
+			);
+		}
+
+		return this.queryChangedSubject.asObservable().pipe(
+			// Wouter: Filter the query that has changed.
+			// This will make sure only the [id] streams are triggered.
+			filter((queryId) => queryId === id),
+			map(() => this.queryListMap.get(id).matches)
+		);
+	}
+
+	/**
+	 * Unregister all media query subscriptions from the service.
+	 */
+	public ngOnDestroy(): void {
+		this.windowService.runInBrowser(() => {
+			// Wouter: Remove all eventListeners
+			for (let [id, query] of this.queryListMap) {
+				query.removeEventListener('change', this.mediaQueryListenerMap.get(id));
+			}
+
+			// Wouter: Complete subscriptions
+			this.queryChangedSubject.next(null);
+			this.queryChangedSubject.complete();
+
+			// Wouter: Clear maps
+			this.queryListMap.clear();
+			this.mediaQueryListenerMap.clear();
+		});
+	}
+}

--- a/libs/utils/src/lib/services/media-query/query.service.md
+++ b/libs/utils/src/lib/services/media-query/query.service.md
@@ -1,0 +1,15 @@
+# NgxMediaQueryService
+
+The `NgxMediaQueryService` provides a SSR proof Observable approach to the changes in the media queries of the `window` object.
+
+## Properties
+
+### registerMediaQueries
+
+Provided one or more media queries, it will setup a steam that can be subscribed to. When the viewport has passed a certain provided breakpoint, the new value of the triggered media query will be emitted onto the stream.
+
+### getMatchingQuery$
+
+Subscribing to this method with a specified `id`, will allow the subscription to be triggered whenever the breakpoint of the matching query has been triggered. It may be important to note that only the subscribers of the triggered breakpoint will emit. Not all provided breakpoints will emit whenever one query changes.
+
+Every subscription will be triggered once upon creation. This allows for the query subscriptions to be used in operators like a `combineLatest`.


### PR DESCRIPTION
# Description

This PR introduces a new service. It allows the user to provide one or more media queries whose changes will be emitted onto a stream. This stream can be subscribed to, but requires an id (the same that was used upon setting the query). If the id of the triggered breakpoint, the id of the triggered query will be emitted onto the stream. Those subscribers whose id matches the id that was pushed onto the stream, will be triggered and will receive the new query value (a boolean).

# Demo

https://github.com/user-attachments/assets/d492f1ec-f169-413d-b5ac-eb7676ec120d

