### PR TITLE
feat(ngx-utils): add a class to the withRouterLinks substitute element

### DIFF
--- a/libs/utils/src/lib/pipes/with-router-links/with-router-links.md
+++ b/libs/utils/src/lib/pipes/with-router-links/with-router-links.md
@@ -90,7 +90,9 @@ Within the template you can now provide the string and transform it like this:
 }]"></p>
 ```
 
-The linkTo will transform your array to a string. It also expects plain string paths instead of arrays.
+The `linkTo` will transform your array to a string. It also expects plain string paths instead of arrays.
+
+The `hostClass` will allow you to set a class onto the host of the substitute element.
 
 #### Deviating from the global settings
 
@@ -102,7 +104,10 @@ If you'd want to deviate from the global settings and use a different component 
     link: ['somewhere', 'in', 'the', 'app'],
     replaceElementSelector: 'my-other-el',
 	toAttribute: 'input-prop',
+    hostClass: 'someClass',
 }]"></p>
 ```
+
+It is possible to redefine a `hostClass` here. Be aware that this will overwrite the `hostClass` defined by the global style.
 
 Do note, again, that Angular will always lowercase attributes on HTML provided through the innerHTML & outerHTML directives.

--- a/libs/utils/src/lib/pipes/with-router-links/with-router-links.pipe.spec.ts
+++ b/libs/utils/src/lib/pipes/with-router-links/with-router-links.pipe.spec.ts
@@ -3,16 +3,22 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { WithRouterLinksConfig } from '../../types';
 import { WithRouterLinkPipe } from './with-router-links.pipe';
 
-describe('WithRouterLinkPipe', () => {
-	const config: WithRouterLinksConfig = {
-		replaceElementSelector: 'my-link',
-		linkAttributeName: 'to',
-		dataLinkIdAttributeName: 'data-link-id',
-	};
+fdescribe('WithRouterLinkPipe', () => {
+	let config: WithRouterLinksConfig;
+	let pipe: WithRouterLinkPipe;
 	const sanitizer: DomSanitizer = {
 		bypassSecurityTrustHtml: jasmine.createSpy().and.callFake((value) => value),
 	} as any as DomSanitizer;
-	const pipe: WithRouterLinkPipe = new WithRouterLinkPipe(config, sanitizer);
+
+	beforeEach(() => {
+		config = {
+			replaceElementSelector: 'my-link',
+			linkAttributeName: 'to',
+			dataLinkIdAttributeName: 'data-link-id',
+		};
+
+		pipe = new WithRouterLinkPipe(config, sanitizer);
+	});
 
 	it('should convert a single link with a an array link & global config', () => {
 		const result = pipe.transform(
@@ -110,6 +116,43 @@ describe('WithRouterLinkPipe', () => {
 
 		expect(result).toBe(
 			`<head></head><body>This is a text with multiple links: <my-link to="path/in/app">link 1</my-link>, <a href="https://studiohyperdrive.be">link 2</a>, <a data-link-id="someUniqueId3">link 3</a>.</body>`
+		);
+	});
+
+	it('should include the class of the global config', () => {
+		config.hostClass = 'globalClass';
+
+		const result = pipe.transform(
+			'This is a text with a <a data-link-id="someUniqueId">link</a>.',
+			[
+				{
+					dataLinkId: 'someUniqueId',
+					link: ['path', 'in', 'app'],
+				},
+			]
+		);
+
+		expect(result).toBe(
+			`<head></head><body>This is a text with a <my-link to="path/in/app" class="globalClass">link</my-link>.</body>`
+		);
+	});
+
+	it('should include the class of the global config', () => {
+		config.hostClass = 'globalClass';
+
+		const result = pipe.transform(
+			'This is a text with a <a data-link-id="someUniqueId">link</a>.',
+			[
+				{
+					dataLinkId: 'someUniqueId',
+					link: ['path', 'in', 'app'],
+					hostClass: 'pipeClass',
+				},
+			]
+		);
+
+		expect(result).toBe(
+			`<head></head><body>This is a text with a <my-link to="path/in/app" class="pipeClass">link</my-link>.</body>`
 		);
 	});
 });

--- a/libs/utils/src/lib/pipes/with-router-links/with-router-links.pipe.ts
+++ b/libs/utils/src/lib/pipes/with-router-links/with-router-links.pipe.ts
@@ -42,10 +42,16 @@ export class WithRouterLinkPipe implements PipeTransform {
 		// The argument defaults to an empty array, if no linkReferences are provided,
 		// it will loop over an empty array.
 		linkReferences.forEach(
-			({ dataLinkId, link, replaceElementSelector, toAttribute }: LinkReference) => {
+			({
+				dataLinkId,
+				link,
+				replaceElementSelector,
+				toAttribute,
+				hostClass,
+			}: LinkReference) => {
 				// Denis: construct the selector string
 				const selector: string = `a[${this.config.dataLinkIdAttributeName}="${dataLinkId}"]`;
-				// Denis: select the palceholder element within the parsed Document.
+				// Denis: select the placeholder element within the parsed Document.
 				const placeholderLink: HTMLElement = body.querySelector(selector);
 
 				// Denis: if no placeholder is found, early return.
@@ -61,6 +67,7 @@ export class WithRouterLinkPipe implements PipeTransform {
 				const parsedLink: HTMLElement = body.createElement(
 					replaceElementSelector || this.config.replaceElementSelector
 				);
+
 				// Denis: because setAttribute expects a string value,
 				// check if the provided routerLinkValue is an Array. If so, join it.
 				const routerLinkValue: string = Array.isArray(link) ? link.join('/') : link;
@@ -72,6 +79,13 @@ export class WithRouterLinkPipe implements PipeTransform {
 					toAttribute || this.config.linkAttributeName,
 					routerLinkValue
 				);
+
+				// Wouter: If provided, set the hostClass provided by the pipe's transform. If no class is defined,
+				// the global config will be used. If no global config is defined either, the class will not be set.
+				if (hostClass || this.config.hostClass) {
+					parsedLink.setAttribute('class', hostClass || this.config.hostClass);
+				}
+
 				// Denis: copy the innerText of the placeholder element to the new element.
 				parsedLink.innerText = placeholderLink.innerText;
 

--- a/libs/utils/src/lib/types/with-router-links.types.ts
+++ b/libs/utils/src/lib/types/with-router-links.types.ts
@@ -2,6 +2,8 @@ export interface WithRouterLinksConfig {
 	replaceElementSelector: string;
 	linkAttributeName: string;
 	dataLinkIdAttributeName: string;
+	/** Add a class to the host of the substitute element. */
+	hostClass?: string;
 }
 
 export interface LinkReference {
@@ -9,4 +11,6 @@ export interface LinkReference {
 	link: string | string[];
 	replaceElementSelector?: string;
 	toAttribute?: string;
+	/** Add a class to the host of the substitute element. This will overwrite the global hostClass of the injection token. */
+	hostClass?: string;
 }


### PR DESCRIPTION
This addition will allow for a custom class to be defined onto the host of the new element through the injection context and the pipe arguments.