### PR TITLE
fix(utils|forms): an import of obj-clean was breaking production builds in codebases that use esModuleInterop with the application builder (ng18+)

### DIFF
--- a/libs/forms/src/lib/validators/all-or-nothing-required/all-or-nothing-required.validator.ts
+++ b/libs/forms/src/lib/validators/all-or-nothing-required/all-or-nothing-required.validator.ts
@@ -1,5 +1,5 @@
 import { FormGroup } from '@angular/forms';
-import * as clean from 'obj-clean';
+import clean from 'obj-clean';
 
 import { clearFormError, setFormError } from '../utils';
 

--- a/libs/forms/src/lib/validators/at-least-one-required/at-least-one-required.validator.ts
+++ b/libs/forms/src/lib/validators/at-least-one-required/at-least-one-required.validator.ts
@@ -1,5 +1,5 @@
 import { FormGroup } from '@angular/forms';
-import * as clean from 'obj-clean';
+import clean from 'obj-clean';
 
 import { clearFormError, setFormError } from '../utils';
 

--- a/libs/forms/src/lib/validators/utils/form-error.util.ts
+++ b/libs/forms/src/lib/validators/utils/form-error.util.ts
@@ -1,5 +1,5 @@
 import { AbstractControl } from '@angular/forms';
-import * as clean from 'obj-clean';
+import clean from 'obj-clean';
 
 /**
  * Removes an error from a form control

--- a/libs/utils/src/lib/pipes/has-values/has-values.pipe.ts
+++ b/libs/utils/src/lib/pipes/has-values/has-values.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from 'lodash';
-import * as clean from 'obj-clean';
+import clean from 'obj-clean';
 
 @Pipe({
 	name: 'hasValues',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,7 +27,8 @@
 		},
 		"useDefineForClassFields": false,
 		"skipLibCheck": true,
-		"rootDir": "."
+		"rootDir": ".",
+    "allowSyntheticDefaultImports": true
 	},
 	"angularCompilerOptions": {
 		"enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
The `import * as clean from "obj-clean"` syntax was breaking ng18+ codebases that use the new application build system:

<img width="1076" alt="Scherm­afbeelding 2024-08-21 om 11 39 14" src="https://github.com/user-attachments/assets/119d132e-a632-4e0f-a26a-c12c6f48fcb5">
