### PR TITLE
feat(ngx-utils): Add replace-elements pipe

### DIFF
--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -160,6 +160,12 @@ The withRouterLinks pipe will provide a way to transform a string that contains 
 
 [Full documentation.](src/lib/pipes/with-router-links/with-router-links.md)
 
+#### NgxReplaceElementsPipe
+
+The ngxReplaceElements pipe will provide a way to transform a string that contains one or more parts that need an Angular component by taking advantage of Angular web components.
+
+[Full documentation.](src/lib/pipes/replace-elements/replace-elements.pipe.md)
+
 ### Services
 
 #### Window service

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -32,7 +32,9 @@
 		"media query",
 		"window resize",
 		"match media",
-		"viewport"
+		"viewport",
+    "replace elements",
+    "web components"
 	],
 	"homepage": "https://github.com/studiohyperdrive/ngx-tools/tree/master/libs/utils",
 	"license": "MIT",

--- a/libs/utils/src/lib/pipes/replace-elements/replace-elements.pipe.md
+++ b/libs/utils/src/lib/pipes/replace-elements/replace-elements.pipe.md
@@ -1,0 +1,98 @@
+# `ngxReplaceElements`
+
+The `ngxReplaceElements` pipe will provide a way to transform a string that contains one or more parts that need an Angular component by taking advantage of Angular web components.
+
+This can be useful in combination with translation strings that require in-app links or WYSIWYG content from an external source.
+
+## How to use
+
+### Set up
+
+The pipe requires a couple of things to be provided before it can be used.
+
+First, create a component that will be used to replace your target:
+
+```typescript
+@Component({
+	selector: 'link',
+	template: '<a [routerLink]="link"></a>',
+})
+export class LinkComponent {
+	// Keep in mind that Angular's innerHTML & outerHTML will convert attributes to lower casing.
+	// This input property will need to be lowercased to make this work.
+	@Input() public link: string;
+}
+```
+
+Then register it as a web component in your `app.component.ts`:
+
+```typescript
+@Component({
+	//...
+})
+export class AppComponent {
+	constructor(
+		// ...
+		private readonly windowService: WindowService,
+		private readonly injector: Injector
+	) {
+		// Note that we are using our WindowService (ngx-utils) to avoid SSR issues.
+		if (this.windowService.isBrowser) {
+			const linkComponent = createCustomElement(LinkComponent, { injector: this.injector });
+
+			customElements.define('ngx-link', linkComponent);
+		}
+	}
+}
+```
+
+Lastly set up the global config in your root provider array:
+
+```typescript
+	providers: [
+		//...
+        provideNgxReplaceElementsConfiguration({
+            link: {
+                element: 'ngx-link',
+                selector:'a[data-link-id={{id}}]',
+                includeInnerText: true
+            },
+            image: {
+                element: 'ngx-image',
+                selector:'img[data-link-id={{id}}]',
+            }
+        })
+	]
+```
+
+For each element we want to register, we define the WebComponent name using the `element` property. In order to be able to select an item to replace later on in the text, we create a `selector`. This selector should **always** include a part to identify the id, being `{{id}}`.
+
+If we wish to use the original innerText of the element whilst replacing, we can do so by setting `includeInnerText` to true.
+
+### Using the pipe
+
+When the web component is set up, you can start using the pipe.
+
+First set up anchors in your input string:
+
+```text
+"This is a text with a <a data-link-id='someUniqueId'>link</a>."
+```
+
+The `someUniqueId` will be used by the pipe to find and replace your link element so make sure that each anchor within your translation has a unique identifier.
+
+Within the template you can now provide the string and transform it like this:
+
+```angular2html
+<p [innerHTML]="string | withRouterLinks : [{
+    id: 'someUniqueId',
+    elementId: link,
+    data: {
+        link: 'somewhere/in/the/app'
+    }
+}]"></p>
+```
+
+Whilst `id` refers to the id in the string, `elementId` refers to the element we have configured in the configuration.
+
+The `data` property can be used to set the inputs of our provided WebComponent. We once again want to stress that due to the nature of WebComponents, these properties can only have lowercase keys.

--- a/libs/utils/src/lib/pipes/replace-elements/replace-elements.pipe.spec.ts
+++ b/libs/utils/src/lib/pipes/replace-elements/replace-elements.pipe.spec.ts
@@ -1,0 +1,88 @@
+import { DomSanitizer } from '@angular/platform-browser';
+import { NgxReplaceElementsConfiguration } from '../../types';
+import { NgxReplaceElementsPipe } from './replace-elements.pipe';
+
+describe('NgxReplaceElementsPipe', () => {
+	const sanitizer: DomSanitizer = {
+		bypassSecurityTrustHtml: jasmine.createSpy().and.callFake((value) => value),
+	} as any as DomSanitizer;
+
+	const configuration: NgxReplaceElementsConfiguration = {
+		button: {
+			includeInnerText: true,
+			element: 'ngx-button',
+			selector: 'button[data-id={{id}}]',
+		},
+		image: {
+			element: 'ngx-image',
+			selector: 'img[data-id={{id}}]',
+		},
+	};
+
+	let pipe: NgxReplaceElementsPipe;
+
+	beforeEach(() => {
+		pipe = new NgxReplaceElementsPipe(configuration, sanitizer);
+	});
+
+	it('should return the original value if there is nothing to replace', () => {
+		const text = 'Hello there this is a button: <button>Test!</button>';
+		const result =
+			'<head></head><body>Hello there this is a button: <button>Test!</button></body>';
+
+		expect(pipe.transform(text, [{ id: 'test', elementId: 'button' }])).toEqual(result);
+	});
+
+	it('should return an empty string if no string value was provided', () => {
+		expect(pipe.transform(undefined, [{ id: 'test', elementId: 'button' }])).toEqual('');
+		expect(pipe.transform(1 as any, [{ id: 'test', elementId: 'button' }])).toEqual('');
+		expect(
+			pipe.transform({ hello: 'world' } as any, [{ id: 'test', elementId: 'button' }])
+		).toEqual('');
+		expect(pipe.transform([1] as any, [{ id: 'test', elementId: 'button' }])).toEqual('');
+		expect(pipe.transform(null, [{ id: 'test', elementId: 'button' }])).toEqual('');
+	});
+
+	it('should replace a single element with innerText', () => {
+		const text = 'Hello there this is a button: <button data-id="test">Test!</button>';
+		const result =
+			'<head></head><body>Hello there this is a button: <ngx-button>Test!</ngx-button></body>';
+
+		expect(pipe.transform(text, [{ id: 'test', elementId: 'button' }])).toEqual(result);
+	});
+
+	it('should replace a single element without innerText', () => {
+		const text = 'Hello there this is a image: <img data-id="test">';
+		const result =
+			'<head></head><body>Hello there this is a image: <ngx-image></ngx-image></body>';
+
+		expect(pipe.transform(text, [{ id: 'test', elementId: 'image' }])).toEqual(result);
+	});
+
+	it('should replace a multiple elements of the same type', () => {
+		const text =
+			'Hello there this is a button: <button data-id="test">Test!</button> and this is also a button: <button data-id="test-2">Test 2!</button>';
+		const result =
+			'<head></head><body>Hello there this is a button: <ngx-button>Test!</ngx-button> and this is also a button: <ngx-button>Test 2!</ngx-button></body>';
+
+		expect(
+			pipe.transform(text, [
+				{ id: 'test', elementId: 'button' },
+				{ id: 'test-2', elementId: 'button' },
+			])
+		).toEqual(result);
+	});
+
+	it('should replace multiple items of different types', () => {
+		const text = '<img data-id="test"></img> <button data-id="test">Download!</button>';
+		const result =
+			'<head></head><body><ngx-image src="image-2"></ngx-image> <ngx-button>Download!</ngx-button></body>';
+
+		expect(
+			pipe.transform(text, [
+				{ id: 'test', elementId: 'image', data: { src: 'image-2' } },
+				{ id: 'test', elementId: 'button' },
+			])
+		).toEqual(result);
+	});
+});

--- a/libs/utils/src/lib/pipes/replace-elements/replace-elements.pipe.ts
+++ b/libs/utils/src/lib/pipes/replace-elements/replace-elements.pipe.ts
@@ -1,0 +1,83 @@
+import { Inject, Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+import { NgxReplaceElementsConfigurationToken } from '../../tokens';
+import { NgxReplaceElementsConfiguration, NgxReplaceElementsItem } from '../../types';
+
+/**
+ * A pipe that allows to replace text elements with a WebComponent
+ */
+@Pipe({
+	name: 'ngxReplaceElements',
+	standalone: true,
+})
+export class NgxReplaceElementsPipe implements PipeTransform {
+	constructor(
+		@Inject(NgxReplaceElementsConfigurationToken)
+		private readonly configuration: NgxReplaceElementsConfiguration,
+		private readonly sanitizer: DomSanitizer
+	) {}
+
+	/**
+	 * Replaces all matches of a specific selector with provided WebComponents
+	 *
+	 * @param value - The original string value
+	 * @param items - The items we wish to replace
+	 */
+	transform(value: string, items: NgxReplaceElementsItem[]): SafeHtml {
+		// Iben: If the value isn't a string we early exit and warn the user
+		if (typeof value !== 'string') {
+			console.warn(
+				'NgxReplaceElements: A non string-value was provided to the NgxReplaceElementsPipe'
+			);
+			return '';
+		}
+
+		// Iben: If no items were provided to replace, we just return the value
+		if (!items || items.length === 0) {
+			return value;
+		}
+
+		// Iben: set up a new instance of the DOMParser and parse the value as text/html.
+		// This will return a Document which we can work with to find/replace elements.
+		const parser: DOMParser = new DOMParser();
+		const body: Document = parser.parseFromString(value, 'text/html');
+
+		// Iben: Loop over all items we wish to replace
+		items.forEach((item) => {
+			// Iben: Get the selector and the element we want to replace the target with
+			const { selector, element, includeInnerText } = this.configuration[item.elementId];
+
+			// Iben: Select the target
+			const target: HTMLElement = body.querySelector(selector.replace('{{id}}', item.id));
+
+			// Iben: If no target was found, early exit
+			if (!target) {
+				return;
+			}
+
+			// Iben: Create a new element within the Document based on the provided selector.
+			// The selector can be any native or custom web component (not an Angular component).
+			// Keep in mind that the element will need to have a lowercase input prop for the reference.
+			const replacement: HTMLElement = body.createElement(element);
+
+			// Iben: If the item included data, we set these attributes
+			if (item.data) {
+				Object.entries(item.data).forEach(([key, value]) => {
+					replacement.setAttribute(key, value);
+				});
+			}
+
+			// Iben: Copy the innerText of the target element to the new element if needed.
+			if (includeInnerText) {
+				replacement.innerText = target.innerText;
+			}
+
+			// Iben: Replace the target with the new element within the Document.
+			target.replaceWith(replacement);
+		});
+
+		// Iben: sanitize the document and mark it as trusted HTML before returning it to the template.
+		return this.sanitizer.bypassSecurityTrustHtml(body.documentElement.innerHTML);
+	}
+}

--- a/libs/utils/src/lib/pipes/with-router-links/with-router-links.pipe.spec.ts
+++ b/libs/utils/src/lib/pipes/with-router-links/with-router-links.pipe.spec.ts
@@ -3,7 +3,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { WithRouterLinksConfig } from '../../types';
 import { WithRouterLinkPipe } from './with-router-links.pipe';
 
-fdescribe('WithRouterLinkPipe', () => {
+describe('WithRouterLinkPipe', () => {
 	let config: WithRouterLinksConfig;
 	let pipe: WithRouterLinkPipe;
 	const sanitizer: DomSanitizer = {

--- a/libs/utils/src/lib/providers/replace-elements/replace-elements.provider.ts
+++ b/libs/utils/src/lib/providers/replace-elements/replace-elements.provider.ts
@@ -1,0 +1,18 @@
+import { Provider } from '@angular/core';
+
+import { NgxReplaceElementsConfigurationToken } from '../../tokens';
+import { NgxReplaceElementsConfiguration } from '../../types';
+
+/**
+ * Provides the configuration for the NgxReplaceElements directive
+ *
+ * @param configuration - The required configuration
+ */
+export const provideNgxReplaceElementsConfiguration = (
+	configuration: NgxReplaceElementsConfiguration
+): Provider => {
+	return {
+		provide: NgxReplaceElementsConfigurationToken,
+		useValue: configuration,
+	};
+};

--- a/libs/utils/src/lib/tokens/index.ts
+++ b/libs/utils/src/lib/tokens/index.ts
@@ -1,0 +1,1 @@
+export * from './replace-elements.token';

--- a/libs/utils/src/lib/tokens/replace-elements.token.ts
+++ b/libs/utils/src/lib/tokens/replace-elements.token.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+import { NgxReplaceElementsConfiguration } from '../types';
+
+/** The configuration token for the NgxReplaceElementsPipe */
+export const NgxReplaceElementsConfigurationToken =
+	new InjectionToken<NgxReplaceElementsConfiguration>('NgxReplaceElementsConfigurationToken');

--- a/libs/utils/src/lib/types/index.ts
+++ b/libs/utils/src/lib/types/index.ts
@@ -1,3 +1,4 @@
 export * from './signals';
 export * from './with-router-links.types';
 export * from './storage.types';
+export * from './replace-elements.types';

--- a/libs/utils/src/lib/types/replace-elements.types.ts
+++ b/libs/utils/src/lib/types/replace-elements.types.ts
@@ -1,0 +1,18 @@
+export type NgxReplaceElementsSelector = `${string}{{id}}${string}`;
+
+export interface NgxReplaceElementsConfigurationElement {
+	element: string;
+	selector: NgxReplaceElementsSelector;
+	includeInnerText?: boolean;
+}
+
+export type NgxReplaceElementsConfiguration = Record<
+	string,
+	NgxReplaceElementsConfigurationElement
+>;
+
+export interface NgxReplaceElementsItem {
+	id: string;
+	elementId: string;
+	data?: Record<Lowercase<string>, string>;
+}


### PR DESCRIPTION
A more generic version of the WithRouterLinks pipe that now allows for any kind of WebComponent to be added