### PR TITLE
feat(ngx-i18n): Make the package cohesive with other packages and add SetLanguageGuard

### DIFF
--- a/apps/i18n-test/src/app/app-routing.module.ts
+++ b/apps/i18n-test/src/app/app-routing.module.ts
@@ -1,11 +1,16 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { I18nGuard } from '@ngx/i18n';
+import { NgxI18nEmptyComponent, NgxI18nGuard, NgxI18nSetLanguageGuard } from '@ngx/i18n';
 
 const routes: Routes = [
 	{
+		path: '',
+		canActivate: [NgxI18nSetLanguageGuard],
+		component: NgxI18nEmptyComponent,
+	},
+	{
 		path: ':language',
-		canActivate: [I18nGuard],
+		canActivate: [NgxI18nGuard],
 		loadChildren: () => import('../feature/feature.routes').then((m) => m.FeatureRoutes),
 	},
 ];

--- a/apps/i18n-test/src/app/app.component.ts
+++ b/apps/i18n-test/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterOutlet } from '@angular/router';
-import { I18nService } from '@ngx/i18n';
+import { NgxI18nService } from '@ngx/i18n';
 
 @Component({
 	selector: 'app-root',
@@ -11,7 +11,7 @@ import { I18nService } from '@ngx/i18n';
 	imports: [RouterOutlet, TranslateModule],
 })
 export class AppComponent {
-	constructor(private readonly i18nService: I18nService) {
+	constructor(private readonly i18nService: NgxI18nService) {
 		i18nService.initI18n('nl').subscribe();
 	}
 }

--- a/apps/i18n-test/src/feature/feature.routes.ts
+++ b/apps/i18n-test/src/feature/feature.routes.ts
@@ -2,14 +2,14 @@ import { Routes } from '@angular/router';
 
 import { FeaturePageComponent } from './pages/feature.component';
 import { FeatureTranslationLoader } from './translation.loader';
-import { TranslationLoaderGuard, provideWithTranslations } from '@ngx/i18n';
+import { NgxI18nTranslationLoaderGuard, provideWithTranslations } from '@ngx/i18n';
 
 export const FeatureRoutes: Routes = [
 	provideWithTranslations(
 		{
 			path: '',
 			component: FeaturePageComponent,
-			canActivate: [TranslationLoaderGuard],
+			canActivate: [NgxI18nTranslationLoaderGuard],
 		},
 		FeatureTranslationLoader
 	),

--- a/apps/i18n-test/src/feature/pages/feature.component.ts
+++ b/apps/i18n-test/src/feature/pages/feature.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { I18nService } from '@ngx/i18n';
+import { NgxI18nService } from '@ngx/i18n';
 
 @Component({
 	selector: 'app-feature-page',
@@ -11,5 +11,5 @@ import { I18nService } from '@ngx/i18n';
 export class FeaturePageComponent {
 	public readonly currentLanguage = this.i18nService.currentLanguage;
 
-	constructor(private readonly i18nService: I18nService) {}
+	constructor(private readonly i18nService: NgxI18nService) {}
 }

--- a/apps/i18n-test/src/feature/translation.loader.ts
+++ b/apps/i18n-test/src/feature/translation.loader.ts
@@ -1,6 +1,6 @@
 import { HttpBackend } from '@angular/common/http';
-import { MultiTranslationHttpLoader } from '@ngx/i18n';
+import { NgxI18nMultiTranslationHttpLoader } from '@ngx/i18n';
 
 export function FeatureTranslationLoader(http: HttpBackend) {
-	return new MultiTranslationHttpLoader(http, ['./assets/feature/']);
+	return new NgxI18nMultiTranslationHttpLoader(http, ['./assets/feature/']);
 }

--- a/apps/i18n-test/src/main.ts
+++ b/apps/i18n-test/src/main.ts
@@ -3,19 +3,16 @@ import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { AppComponent } from './app/app.component';
 import { AppRoutingModule } from './app/app-routing.module';
-import { NgxI18nModule } from '@ngx/i18n';
+import { importNgxI18nProviders } from '@ngx/i18n';
 
 bootstrapApplication(AppComponent, {
 	providers: [
-		importProvidersFrom(
-			BrowserModule,
-			AppRoutingModule,
-			NgxI18nModule.forRoot({
-				defaultLanguage: 'nl',
-				availableLanguages: ['nl', 'fr'],
-				defaultAssetPaths: ['./assets/shared/'],
-			})
-		),
+		importProvidersFrom(BrowserModule, AppRoutingModule),
+		importNgxI18nProviders({
+			defaultLanguage: 'nl',
+			availableLanguages: ['nl', 'fr'],
+			defaultAssetPaths: ['./assets/shared/'],
+		}),
 		provideHttpClient(withInterceptorsFromDi()),
 	],
 }).catch((err) => console.error(err));

--- a/libs/i18n/.eslintrc.json
+++ b/libs/i18n/.eslintrc.json
@@ -19,7 +19,6 @@
 					"error",
 					{
 						"type": "element",
-						"prefix": "i18n",
 						"style": "kebab-case"
 					}
 				],
@@ -27,7 +26,6 @@
 					"error",
 					{
 						"type": "attribute",
-						"prefix": "i18n",
 						"style": "camelCase"
 					}
 				],

--- a/libs/i18n/src/lib/abstracts/i18n-service.abstract.ts
+++ b/libs/i18n/src/lib/abstracts/i18n-service.abstract.ts
@@ -1,3 +1,3 @@
-export abstract class AbstractI18nService<Language = string> {
+export abstract class NgxI18nAbstractService<Language = string> {
 	public abstract get currentLanguage(): Language;
 }

--- a/libs/i18n/src/lib/components/empty-component/empty.component.ts
+++ b/libs/i18n/src/lib/components/empty-component/empty.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+/**
+ * This is an empty dummy component that can be used in combination with the NgxI18nSetLanguageGuard when needed
+ */
+@Component({
+	selector: 'ngx-i18n-empty',
+	standalone: true,
+	template: '',
+})
+export class NgxI18nEmptyComponent {}

--- a/libs/i18n/src/lib/components/index.ts
+++ b/libs/i18n/src/lib/components/index.ts
@@ -1,0 +1,1 @@
+export * from './empty-component/empty.component';

--- a/libs/i18n/src/lib/guards/i18n/i18n.guard.spec.ts
+++ b/libs/i18n/src/lib/guards/i18n/i18n.guard.spec.ts
@@ -1,41 +1,39 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, Router, convertToParamMap } from '@angular/router';
 
-import { I18nService, RootI18nService } from '../../services';
+import { NgxI18nRootService } from '../../services';
 
-import { I18N_CONFIG } from '../../i18n.const';
-import { I18nGuard } from './i18n.guard';
+import { NgxI18nConfigurationToken } from '../../tokens/i18n.token';
+import { NgxI18nGuard } from './i18n.guard';
 
-describe('I18nGuard', () => {
+describe('NgxI18nGuard', () => {
 	const router: any = {
 		navigate: jasmine.createSpy(),
 	};
 	const i18nService: any = {
 		currentLanguage: 'nl',
-		getCurrentLanguageForRoute: jasmine.createSpy().and.returnValue('nl'),
 		availableLanguages: ['nl', 'en'],
-		setLanguage: jasmine.createSpy(),
+		setCurrentLanguage: jasmine.createSpy(),
 	};
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			providers: [
 				{
-					provide: I18N_CONFIG,
+					provide: NgxI18nConfigurationToken,
 					useValue: {
 						defaultLanguage: 'nl',
 						availableLanguages: ['nl', 'en'],
 					},
 				},
 				{
-					provide: I18nService,
+					provide: NgxI18nRootService,
 					useValue: i18nService,
 				},
 				{
 					provide: Router,
 					useValue: router,
 				},
-				RootI18nService,
 			],
 		});
 	});
@@ -46,7 +44,7 @@ describe('I18nGuard', () => {
 				paramMap: convertToParamMap({ language: 'nl' }),
 			} as ActivatedRouteSnapshot;
 
-			expect(I18nGuard(route, undefined)).toBe(true);
+			expect(NgxI18nGuard(route, undefined)).toBe(true);
 
 			route = {
 				parent: {
@@ -55,7 +53,7 @@ describe('I18nGuard', () => {
 				paramMap: convertToParamMap({}),
 			} as ActivatedRouteSnapshot;
 
-			expect(I18nGuard(route, undefined)).toBe(true);
+			expect(NgxI18nGuard(route, undefined)).toBe(true);
 		});
 	});
 
@@ -65,8 +63,8 @@ describe('I18nGuard', () => {
 				paramMap: convertToParamMap({ language: 'en' }),
 			} as ActivatedRouteSnapshot;
 
-			expect(I18nGuard(route, undefined)).toBe(true);
-			expect(i18nService.setLanguage).toHaveBeenCalledWith('en');
+			expect(NgxI18nGuard(route, undefined)).toBe(true);
+			expect(i18nService.setCurrentLanguage).toHaveBeenCalledWith('en');
 			expect(router.navigate).toHaveBeenCalledWith(['/', 'en']);
 
 			route = {
@@ -76,8 +74,8 @@ describe('I18nGuard', () => {
 				paramMap: convertToParamMap({}),
 			} as ActivatedRouteSnapshot;
 
-			expect(I18nGuard(route, undefined)).toBe(true);
-			expect(i18nService.setLanguage).toHaveBeenCalledWith('en');
+			expect(NgxI18nGuard(route, undefined)).toBe(true);
+			expect(i18nService.setCurrentLanguage).toHaveBeenCalledWith('en');
 			expect(router.navigate).toHaveBeenCalledWith(['/', 'en']);
 		});
 	});
@@ -88,7 +86,7 @@ describe('I18nGuard', () => {
 				paramMap: convertToParamMap({ language: 'de' }),
 			} as ActivatedRouteSnapshot;
 
-			expect(I18nGuard(route, undefined)).toBe(false);
+			expect(NgxI18nGuard(route, undefined)).toBe(false);
 			expect(router.navigate).toHaveBeenCalledWith(['/', 'nl']);
 
 			route = {
@@ -98,7 +96,7 @@ describe('I18nGuard', () => {
 				paramMap: convertToParamMap({}),
 			} as ActivatedRouteSnapshot;
 
-			expect(I18nGuard(route, undefined)).toBe(false);
+			expect(NgxI18nGuard(route, undefined)).toBe(false);
 			expect(router.navigate).toHaveBeenCalledWith(['/', 'nl']);
 		});
 	});

--- a/libs/i18n/src/lib/guards/i18n/i18n.guard.ts
+++ b/libs/i18n/src/lib/guards/i18n/i18n.guard.ts
@@ -1,20 +1,20 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 
-import { I18nService } from '../../services';
-import { I18N_CONFIG } from '../../i18n.const';
-import { I18nConfig } from '../../i18n.types';
+import { NgxI18nRootService } from '../../services';
+import { NgxI18nConfiguration } from '../../i18n.types';
+import { NgxI18nConfigurationToken } from '../../tokens';
 
 /**
  * Set the language in the url of the route
  *
  * @param route - The provided route
  */
-export const I18nGuard: CanActivateFn = (route: ActivatedRouteSnapshot): boolean => {
+export const NgxI18nGuard: CanActivateFn = (route: ActivatedRouteSnapshot): boolean => {
 	// Iben: Fetch all injectables
 	const router: Router = inject(Router);
-	const i18nService = inject(I18nService);
-	const config: I18nConfig = inject(I18N_CONFIG);
+	const i18nService = inject(NgxI18nRootService);
+	const config: NgxI18nConfiguration = inject(NgxI18nConfigurationToken);
 
 	// Iben: Get the two language params
 	const currentLanguage = i18nService.currentLanguage || config.defaultLanguage;
@@ -28,7 +28,7 @@ export const I18nGuard: CanActivateFn = (route: ActivatedRouteSnapshot): boolean
 	// Iben: If the router language differs, we check if it is available
 	if (config?.availableLanguages.includes(routeLanguage)) {
 		// Iben: Update the language
-		i18nService.setLanguage(routeLanguage);
+		i18nService.setCurrentLanguage(routeLanguage);
 
 		//Iben: Re-route to the new language
 		router.navigate(['/', routeLanguage]);
@@ -48,7 +48,7 @@ export const I18nGuard: CanActivateFn = (route: ActivatedRouteSnapshot): boolean
  * @param route - The provided route
  * @param config - The provided config
  */
-const getLanguage = (route: ActivatedRouteSnapshot, config: I18nConfig): string => {
+const getLanguage = (route: ActivatedRouteSnapshot, config: NgxI18nConfiguration): string => {
 	const language = route?.paramMap.get(config.languageRouteParam || 'language');
 	const parent = route?.parent;
 

--- a/libs/i18n/src/lib/guards/index.ts
+++ b/libs/i18n/src/lib/guards/index.ts
@@ -1,2 +1,3 @@
 export * from './i18n/i18n.guard';
 export * from './translation-loader/translation-loader.guard';
+export * from './set-language/set-language.guard';

--- a/libs/i18n/src/lib/guards/set-language/set-language.guard.ts
+++ b/libs/i18n/src/lib/guards/set-language/set-language.guard.ts
@@ -1,0 +1,26 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { NgxI18nRootService } from '../../services';
+import { NgxI18nConfigurationToken } from '../../tokens';
+import { NgxI18nConfiguration } from '../../i18n.types';
+
+/**
+ * Set the language in the url of the route
+ *
+ * @param route - The provided route
+ */
+export const NgxI18nSetLanguageGuard: CanActivateFn = (): Promise<boolean> => {
+	// Iben: Fetch all injectables
+	const router: Router = inject(Router);
+	const i18nService = inject(NgxI18nRootService);
+	const config: NgxI18nConfiguration = inject(NgxI18nConfigurationToken);
+
+	// Iben: If no language was set already, we set the default language
+	if (!i18nService.currentLanguage) {
+		i18nService.setCurrentLanguage(config.defaultLanguage);
+	}
+
+	//Iben: Navigate to the set currentLanguage
+	return router.navigate(['/', i18nService.currentLanguage]);
+};

--- a/libs/i18n/src/lib/guards/translation-loader/translation-loader.guard.spec.ts
+++ b/libs/i18n/src/lib/guards/translation-loader/translation-loader.guard.spec.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { TranslationLoaderResolver } from '../../resolvers';
-import { I18nService } from '../../services';
-import { TranslationLoaderGuard } from './translation-loader.guard';
+import { NgxI18nTranslationLoaderResolver } from '../../resolvers';
+import { NgxI18nService } from '../../services';
+import { NgxI18nTranslationLoaderGuard } from './translation-loader.guard';
 
-describe('TranslationLoaderGuard', () => {
+describe('NgxI18nTranslationLoaderGuard', () => {
 	describe('with resolver provided', () => {
 		const router: any = {
 			navigate: jasmine.createSpy(),
@@ -19,7 +19,7 @@ describe('TranslationLoaderGuard', () => {
 						useValue: router,
 					},
 					{
-						provide: TranslationLoaderResolver,
+						provide: NgxI18nTranslationLoaderResolver,
 						useValue: null,
 					},
 				],
@@ -30,7 +30,7 @@ describe('TranslationLoaderGuard', () => {
 			TestBed.runInInjectionContext(() => {
 				const route = {} as ActivatedRouteSnapshot;
 
-				expect(TranslationLoaderGuard(route, null)).toBe(false);
+				expect(NgxI18nTranslationLoaderGuard(route, null)).toBe(false);
 			});
 		});
 	});
@@ -41,7 +41,6 @@ describe('TranslationLoaderGuard', () => {
 		};
 		const i18nService: any = {
 			currentLanguage: 'nl',
-			getCurrentLanguageForRoute: jasmine.createSpy().and.returnValue('nl'),
 			availableLanguages: ['nl', 'en'],
 			setLanguage: jasmine.createSpy(),
 			initI18n: jasmine.createSpy().and.returnValue(of(true)),
@@ -55,10 +54,10 @@ describe('TranslationLoaderGuard', () => {
 						useValue: router,
 					},
 					{
-						provide: I18nService,
+						provide: NgxI18nService,
 						useValue: i18nService,
 					},
-					TranslationLoaderResolver,
+					NgxI18nTranslationLoaderResolver,
 				],
 			});
 		});
@@ -67,7 +66,7 @@ describe('TranslationLoaderGuard', () => {
 			TestBed.runInInjectionContext(() => {
 				const route = {} as ActivatedRouteSnapshot;
 
-				expect(TranslationLoaderGuard(route, null)).toBeInstanceOf(Observable);
+				expect(NgxI18nTranslationLoaderGuard(route, null)).toBeInstanceOf(Observable);
 			});
 		});
 	});

--- a/libs/i18n/src/lib/guards/translation-loader/translation-loader.guard.ts
+++ b/libs/i18n/src/lib/guards/translation-loader/translation-loader.guard.ts
@@ -1,14 +1,14 @@
 import { inject } from '@angular/core';
 import { CanActivateFn } from '@angular/router';
 
-import { TranslationLoaderResolver } from '../../resolvers';
+import { NgxI18nTranslationLoaderResolver } from '../../resolvers';
 
 /**
  * Loads in all translations for a specific module
  */
-export const TranslationLoaderGuard: CanActivateFn = (): ReturnType<CanActivateFn> => {
+export const NgxI18nTranslationLoaderGuard: CanActivateFn = (): ReturnType<CanActivateFn> => {
 	// Iben: Fetch all injectables
-	const loader: TranslationLoaderResolver = inject(TranslationLoaderResolver);
+	const loader: NgxI18nTranslationLoaderResolver = inject(NgxI18nTranslationLoaderResolver);
 
 	if (!loader) {
 		return false;

--- a/libs/i18n/src/lib/i18n.const.ts
+++ b/libs/i18n/src/lib/i18n.const.ts
@@ -1,4 +1,0 @@
-import { InjectionToken } from '@angular/core';
-import { I18nConfig } from './i18n.types';
-
-export const I18N_CONFIG = new InjectionToken<I18nConfig>('I18N_CONFIG');

--- a/libs/i18n/src/lib/i18n.module.ts
+++ b/libs/i18n/src/lib/i18n.module.ts
@@ -2,18 +2,18 @@ import { ModuleWithProviders, NgModule, inject } from '@angular/core';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
 import { HttpBackend } from '@angular/common/http';
-import { I18nConfig } from './i18n.types';
-import { I18N_CONFIG } from './i18n.const';
-import { MultiTranslationHttpLoader } from './loader';
-import { I18nService } from './services';
-import { TranslationLoaderResolver } from './resolvers';
+import { NgxI18nConfiguration } from './i18n.types';
+import { NgxI18nConfigurationToken } from './tokens/i18n.token';
+import { NgxI18nMultiTranslationHttpLoader } from './loader';
+import { NgxI18nService } from './services';
+import { NgxI18nTranslationLoaderResolver } from './resolvers';
 
 function FallBackTranslationLoader(http: HttpBackend) {
 	// Iben: Inject the config
-	const config = inject(I18N_CONFIG);
+	const config = inject(NgxI18nConfigurationToken);
 
 	// Iben: Return a default loader
-	return new MultiTranslationHttpLoader(http, config.defaultAssetPaths || []);
+	return new NgxI18nMultiTranslationHttpLoader(http, config.defaultAssetPaths || []);
 }
 
 @NgModule({
@@ -22,8 +22,8 @@ function FallBackTranslationLoader(http: HttpBackend) {
 })
 export class NgxI18nModule {
 	public static forRoot(
-		config: I18nConfig,
-		translationLoader?: (http: HttpBackend) => MultiTranslationHttpLoader
+		config: NgxI18nConfiguration,
+		translationLoader?: (http: HttpBackend) => NgxI18nMultiTranslationHttpLoader
 	): ModuleWithProviders<NgxI18nModule> {
 		const providers = [
 			...TranslateModule.forRoot({
@@ -35,10 +35,10 @@ export class NgxI18nModule {
 				useDefaultLang: true,
 			}).providers,
 			{
-				provide: I18N_CONFIG,
+				provide: NgxI18nConfigurationToken,
 				useValue: config,
 			},
-			I18nService,
+			NgxI18nService,
 		];
 
 		return {
@@ -48,7 +48,7 @@ export class NgxI18nModule {
 	}
 
 	public static forChild(
-		translationLoader?: (http: HttpBackend) => MultiTranslationHttpLoader
+		translationLoader?: (http: HttpBackend) => NgxI18nMultiTranslationHttpLoader
 	): ModuleWithProviders<NgxI18nModule> {
 		const providers = [
 			...TranslateModule.forChild({
@@ -59,8 +59,8 @@ export class NgxI18nModule {
 				},
 				isolate: true,
 			}).providers,
-			I18nService,
-			TranslationLoaderResolver,
+			NgxI18nService,
+			NgxI18nTranslationLoaderResolver,
 		];
 
 		return {

--- a/libs/i18n/src/lib/i18n.types.ts
+++ b/libs/i18n/src/lib/i18n.types.ts
@@ -1,4 +1,4 @@
-export interface I18nConfig {
+export interface NgxI18nConfiguration {
 	defaultLanguage: string;
 	availableLanguages: string[];
 	defaultAssetPaths: string[];

--- a/libs/i18n/src/lib/index.ts
+++ b/libs/i18n/src/lib/index.ts
@@ -3,8 +3,9 @@ export * from './guards';
 export * from './loader';
 export * from './resolvers';
 export * from './services';
+export * from './components';
 
-export * from './i18n.const';
+export * from './tokens/i18n.token';
 export * from './i18n.types';
 
 export * from './i18n.module';

--- a/libs/i18n/src/lib/loader/multi-translation/multi-translation.loader.ts
+++ b/libs/i18n/src/lib/loader/multi-translation/multi-translation.loader.ts
@@ -5,10 +5,11 @@ import { deepmerge } from 'deepmerge-ts';
 import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import { I18nLoadingService } from '../../services';
+import { NgxI18nLoadingService } from '../../services';
 
-export class MultiTranslationHttpLoader implements TranslateLoader {
-	private readonly translationLoadingService: I18nLoadingService = inject(I18nLoadingService);
+export class NgxI18nMultiTranslationHttpLoader implements TranslateLoader {
+	private readonly translationLoadingService: NgxI18nLoadingService =
+		inject(NgxI18nLoadingService);
 
 	constructor(
 		private readonly httpBackend: HttpBackend,

--- a/libs/i18n/src/lib/providers/i18n.providers.ts
+++ b/libs/i18n/src/lib/providers/i18n.providers.ts
@@ -3,8 +3,8 @@ import { HttpBackend } from '@angular/common/http';
 
 import { Route } from '@angular/router';
 import { NgxI18nModule } from '../i18n.module';
-import { I18nConfig } from '../i18n.types';
-import { MultiTranslationHttpLoader } from '../loader';
+import { NgxI18nConfiguration } from '../i18n.types';
+import { NgxI18nMultiTranslationHttpLoader } from '../loader';
 
 /**
  * Returns the root providers for the NgxI18nModule
@@ -13,8 +13,8 @@ import { MultiTranslationHttpLoader } from '../loader';
  * @param translationLoader - An optional translation loader
  */
 export const importNgxI18nProviders = (
-	config: I18nConfig,
-	translationLoader?: (http: HttpBackend) => MultiTranslationHttpLoader
+	config: NgxI18nConfiguration,
+	translationLoader?: (http: HttpBackend) => NgxI18nMultiTranslationHttpLoader
 ): (Provider | EnvironmentProviders)[] => {
 	// Iben: Return the providers from the module
 	return [importProvidersFrom(NgxI18nModule.forRoot(config, translationLoader))];
@@ -28,7 +28,7 @@ export const importNgxI18nProviders = (
  */
 export const provideWithTranslations = (
 	route: Route,
-	translationLoader?: (http: HttpBackend) => MultiTranslationHttpLoader
+	translationLoader?: (http: HttpBackend) => NgxI18nMultiTranslationHttpLoader
 ): Route => {
 	// Iben: Grab the existing route and extend the providers with the providers from the module
 	return {

--- a/libs/i18n/src/lib/resolvers/i18n/i18n.resolver.spec.ts
+++ b/libs/i18n/src/lib/resolvers/i18n/i18n.resolver.spec.ts
@@ -1,5 +1,5 @@
 import { finalize, of, Subscription } from 'rxjs';
-import { TranslationLoaderResolver } from './i18n.resolver';
+import { NgxI18nTranslationLoaderResolver } from './i18n.resolver';
 import objectContaining = jasmine.objectContaining;
 
 const i18nService: any = {
@@ -11,7 +11,7 @@ const i18nLoadingService: any = {
 	dispatchTranslationLoaderAction: jasmine.createSpy(),
 };
 
-describe('TranslationLoaderResolver', () => {
+describe('NgxI18nTranslationLoaderResolver', () => {
 	let subscriptions: Subscription[] = [];
 
 	afterEach(() => {
@@ -20,7 +20,7 @@ describe('TranslationLoaderResolver', () => {
 
 	describe('resolve', () => {
 		it('should trigger the initI18n method and set the translation loader to loaded', (done: DoneFn) => {
-			const resolver = new TranslationLoaderResolver(i18nService, i18nLoadingService);
+			const resolver = new NgxI18nTranslationLoaderResolver(i18nService, i18nLoadingService);
 
 			subscriptions.push(
 				resolver

--- a/libs/i18n/src/lib/resolvers/i18n/i18n.resolver.ts
+++ b/libs/i18n/src/lib/resolvers/i18n/i18n.resolver.ts
@@ -2,17 +2,17 @@ import { Injectable } from '@angular/core';
 import { UUID } from 'angular2-uuid';
 import { finalize, map, Observable } from 'rxjs';
 
-import { I18nLoadingService, I18nService } from '../../services';
+import { NgxI18nLoadingService, NgxI18nService } from '../../services';
 
 /**
- * This TranslationLoaderResolver will make sure that the translations are loaded from the moment you route to a detail module
+ * This NgxI18nTranslationLoaderResolver will make sure that the translations are loaded from the moment you route to a detail module
  * It is essential you put this resolver at the root of your modules, whether it be lazy loaded through the guard or calling the resolver in the constructor
  */
 @Injectable()
-export class TranslationLoaderResolver {
+export class NgxI18nTranslationLoaderResolver {
 	constructor(
-		private readonly i18nService: I18nService,
-		private readonly i18nLoadingService: I18nLoadingService
+		private readonly i18nService: NgxI18nService,
+		private readonly i18nLoadingService: NgxI18nLoadingService
 	) {}
 
 	public resolve(): Observable<boolean> {

--- a/libs/i18n/src/lib/services/i18n-loading/i18n-loading.service.spec.ts
+++ b/libs/i18n/src/lib/services/i18n-loading/i18n-loading.service.spec.ts
@@ -1,8 +1,8 @@
 import { filter, last, Observable, of, Subscription, switchMap, take } from 'rxjs';
-import { I18nLoadingService } from './i18n-loading.service';
+import { NgxI18nLoadingService } from './i18n-loading.service';
 import { TranslationLoaderActionEntity } from './i18n-loading.types';
 
-describe('I18nLoadingService', () => {
+describe('NgxI18nLoadingService', () => {
 	let subscriptions: Subscription[] = [];
 
 	afterEach(() => {
@@ -12,7 +12,7 @@ describe('I18nLoadingService', () => {
 	xdescribe('observables', () => {
 		describe('translationsLoaded$', () => {
 			it('should return false if no results have been found', (done: DoneFn) => {
-				const service = new I18nLoadingService();
+				const service = new NgxI18nLoadingService();
 
 				subscriptions.push(
 					service['translationLoaderActionsSubject$']
@@ -36,7 +36,7 @@ describe('I18nLoadingService', () => {
 			});
 
 			it('should return true if results have been found', (done: DoneFn) => {
-				const service = new I18nLoadingService();
+				const service = new NgxI18nLoadingService();
 
 				subscriptions.push(
 					service['translationLoaderActionsSubject$']
@@ -63,7 +63,7 @@ describe('I18nLoadingService', () => {
 
 	describe('dispatchTranslationLoaderAction', () => {
 		it('should push a new action to the translationLoaderActionsSubject$', (done: DoneFn) => {
-			const service = new I18nLoadingService();
+			const service = new NgxI18nLoadingService();
 			const action: TranslationLoaderActionEntity = {
 				id: 'test-id',
 				state: 'LOADING',
@@ -85,7 +85,7 @@ describe('I18nLoadingService', () => {
 
 	describe('addLoadedTranslations', () => {
 		it('should merge & push a new value to the translationsSubject$', (done: DoneFn) => {
-			const service = new I18nLoadingService();
+			const service = new NgxI18nLoadingService();
 			const existingTranslations: Record<string, unknown> = {
 				en: 'test-translation',
 			};
@@ -123,7 +123,7 @@ describe('I18nLoadingService', () => {
 
 	describe('getTranslations', () => {
 		it('should get return the current value of the translationsSubject$', (done: DoneFn) => {
-			const service = new I18nLoadingService();
+			const service = new NgxI18nLoadingService();
 			const existingTranslations: Record<string, unknown> = {
 				en: 'test-translation',
 			};
@@ -142,7 +142,7 @@ describe('I18nLoadingService', () => {
 
 	describe('loadTranslations', () => {
 		it('should create a new entries in the translationsLoading record if the path does not exist', (done: DoneFn) => {
-			const service = new I18nLoadingService();
+			const service = new NgxI18nLoadingService();
 
 			service['translationsLoading'] = {};
 
@@ -167,7 +167,7 @@ describe('I18nLoadingService', () => {
 		});
 
 		it('should return the existing observable if it exists', (done: DoneFn) => {
-			const service = new I18nLoadingService();
+			const service = new NgxI18nLoadingService();
 
 			service['translationsLoading'] = {
 				something: of({
@@ -196,7 +196,7 @@ describe('I18nLoadingService', () => {
 
 	describe('markTranslationsLoadedAsFailed', () => {
 		it('should push a false value the translationsFailedSubject$', (done: DoneFn) => {
-			const service = new I18nLoadingService();
+			const service = new NgxI18nLoadingService();
 
 			service['translationsFailedSubject$']
 				.pipe(take(2), last())

--- a/libs/i18n/src/lib/services/i18n-loading/i18n-loading.service.ts
+++ b/libs/i18n/src/lib/services/i18n-loading/i18n-loading.service.ts
@@ -7,7 +7,7 @@ import { TranslationLoaderActionEntity } from './i18n-loading.types';
 @Injectable({
 	providedIn: 'root',
 })
-export class I18nLoadingService {
+export class NgxI18nLoadingService {
 	// Iben: Keep a subject to store all the translation loading actions
 	private readonly translationLoaderActionsSubject$ =
 		new Subject<TranslationLoaderActionEntity>();

--- a/libs/i18n/src/lib/services/i18n/i18n.service.spec.ts
+++ b/libs/i18n/src/lib/services/i18n/i18n.service.spec.ts
@@ -1,5 +1,5 @@
 import { of, Subscription } from 'rxjs';
-import { I18nService } from './i18n.service';
+import { NgxI18nService } from './i18n.service';
 
 const translateService: any = {
 	currentLang: 'nl',
@@ -19,8 +19,8 @@ const rootI18nService: any = {
 	currentLanguage: translateService.currentLang,
 };
 
-describe('I18nService', () => {
-	const service = new I18nService(translateService, rootI18nService);
+describe('NgxI18nService', () => {
+	const service = new NgxI18nService(translateService, rootI18nService);
 
 	let subscriptions: Subscription[] = [];
 

--- a/libs/i18n/src/lib/services/i18n/i18n.service.ts
+++ b/libs/i18n/src/lib/services/i18n/i18n.service.ts
@@ -2,14 +2,14 @@ import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 
-import { AbstractI18nService } from '../../abstracts';
-import { RootI18nService } from '../root-i18n/root-i18n.service';
+import { NgxI18nAbstractService } from '../../abstracts';
+import { NgxI18nRootService } from '../root-i18n/root-i18n.service';
 
 @Injectable()
-export class I18nService implements AbstractI18nService {
+export class NgxI18nService implements NgxI18nAbstractService {
 	constructor(
 		private readonly translateService: TranslateService,
-		private readonly rootI18nService: RootI18nService
+		private readonly rootI18nService: NgxI18nRootService
 	) {}
 
 	/**
@@ -44,7 +44,7 @@ export class I18nService implements AbstractI18nService {
 			this.rootI18nService.setCurrentLanguage(language);
 		}
 
-		this.translateService.use(language || this.rootI18nService.currentLanguage);
+		this.translateService.use(this.rootI18nService.currentLanguage);
 
 		return this.translateService.reloadLang(language);
 	}
@@ -55,8 +55,8 @@ export class I18nService implements AbstractI18nService {
 	 * @param language - The provided language
 	 */
 	public setLanguage = (language: string): void => {
-		this.translateService.use(language);
 		this.rootI18nService.setCurrentLanguage(language);
+		this.translateService.use(this.rootI18nService.currentLanguage);
 	};
 
 	/**

--- a/libs/i18n/src/lib/services/root-i18n/root-i18n.service.ts
+++ b/libs/i18n/src/lib/services/root-i18n/root-i18n.service.ts
@@ -1,20 +1,63 @@
-import { Injectable } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
+import { NgxI18nConfiguration } from '../../i18n.types';
+import { NgxI18nConfigurationToken } from '../../tokens';
+
+//TODO: Iben: Once we have a shared lib we should replace the storage and the browser approaches with their corresponding implementations
 @Injectable({ providedIn: 'root' })
-export class RootI18nService {
+export class NgxI18nRootService {
+	/**
+	 * A subject to hold the current language
+	 */
 	private readonly currentLanguageSubject: BehaviorSubject<string> = new BehaviorSubject<string>(
 		undefined
 	);
 
+	constructor(
+		@Inject(PLATFORM_ID) private readonly platformId: string,
+		@Inject(NgxI18nConfigurationToken)
+		private readonly configuration: NgxI18nConfiguration
+	) {}
+
+	/**
+	 * The current language of the application, as an Observable
+	 */
 	public readonly currentLanguage$: Observable<string> =
 		this.currentLanguageSubject.asObservable();
 
+	/**
+	 * The current language of the application
+	 */
 	public get currentLanguage(): string {
 		return this.currentLanguageSubject.getValue();
 	}
 
-	public setCurrentLanguage(language: string) {
+	/**
+	 * Sets the current language of the application and saves it to the local storage. Returns true if the language was set
+	 *
+	 * @param language - The provided language
+	 */
+	public setCurrentLanguage(language: string): void {
+		// Iben: If a language is set that's not part of the available languages, we return a warn
+		if (!this.configuration.availableLanguages.includes(language)) {
+			console.warn(
+				`NgxI18n: A language, ${language}, was attempted to be set that was not part of the available languages (${this.configuration.availableLanguages.join(
+					', '
+				)})`
+			);
+
+			// Iben: Early exit
+			return;
+		}
+
+		// Iben: Save the current language to the localStorage when we're in the browser
+		if (isPlatformBrowser(this.platformId)) {
+			localStorage.setItem('ngx-language', language);
+		}
+
+		// Iben: Update the subject
 		this.currentLanguageSubject.next(language);
 	}
 }

--- a/libs/i18n/src/lib/tokens/i18n.token.ts
+++ b/libs/i18n/src/lib/tokens/i18n.token.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+import { NgxI18nConfiguration } from '../i18n.types';
+
+export const NgxI18nConfigurationToken = new InjectionToken<NgxI18nConfiguration>(
+	'NgxI18nConfigurationToken'
+);

--- a/libs/i18n/src/lib/tokens/index.ts
+++ b/libs/i18n/src/lib/tokens/index.ts
@@ -1,0 +1,1 @@
+export * from './i18n.token';


### PR DESCRIPTION
This PR does two things.

1. It renames the services, guards, etc. to be more cohesive with the other packages. Now it is clear they're part of the ngx-i18n package. I at first wanted to write a migration script, but unfortunately did not have the time.
2. It adds a new guard that will automatically set the language 
3. It makes the root I18nService clearer