### PR TITLE
fix(ngx-i18n): Add initializeLanguage

### DIFF
--- a/libs/i18n/src/lib/guards/i18n/i18n.guard.spec.ts
+++ b/libs/i18n/src/lib/guards/i18n/i18n.guard.spec.ts
@@ -14,6 +14,7 @@ describe('NgxI18nGuard', () => {
 		currentLanguage: 'nl',
 		availableLanguages: ['nl', 'en'],
 		setCurrentLanguage: jasmine.createSpy(),
+		initializeLanguage: jasmine.createSpy(),
 	};
 
 	beforeEach(() => {

--- a/libs/i18n/src/lib/guards/i18n/i18n.guard.ts
+++ b/libs/i18n/src/lib/guards/i18n/i18n.guard.ts
@@ -16,8 +16,11 @@ export const NgxI18nGuard: CanActivateFn = (route: ActivatedRouteSnapshot): bool
 	const i18nService = inject(NgxI18nRootService);
 	const config: NgxI18nConfiguration = inject(NgxI18nConfigurationToken);
 
+	// Iben: Initialize the current language of the application
+	i18nService.initializeLanguage();
+
 	// Iben: Get the two language params
-	const currentLanguage = i18nService.currentLanguage || config.defaultLanguage;
+	const currentLanguage = i18nService.currentLanguage;
 	const routeLanguage = getLanguage(route, config);
 
 	// Iben: If both languages are the same, we can continue

--- a/libs/i18n/src/lib/guards/set-language/set-language.guard.ts
+++ b/libs/i18n/src/lib/guards/set-language/set-language.guard.ts
@@ -2,8 +2,6 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 
 import { NgxI18nRootService } from '../../services';
-import { NgxI18nConfigurationToken } from '../../tokens';
-import { NgxI18nConfiguration } from '../../i18n.types';
 
 /**
  * Set the language in the url of the route
@@ -14,12 +12,9 @@ export const NgxI18nSetLanguageGuard: CanActivateFn = (): Promise<boolean> => {
 	// Iben: Fetch all injectables
 	const router: Router = inject(Router);
 	const i18nService = inject(NgxI18nRootService);
-	const config: NgxI18nConfiguration = inject(NgxI18nConfigurationToken);
 
-	// Iben: If no language was set already, we set the default language
-	if (!i18nService.currentLanguage) {
-		i18nService.setCurrentLanguage(config.defaultLanguage);
-	}
+	// Iben: Initialize the current language of the application
+	i18nService.initializeLanguage();
 
 	//Iben: Navigate to the set currentLanguage
 	return router.navigate(['/', i18nService.currentLanguage]);


### PR DESCRIPTION
The SetLanguageGuard takes care of initializing the language when no language was set and this works perfectly when the language is not part of the route yet.

However, when the language parameter was already set, the guard is not called and the I18nGuard did not initialize the language. This PR fixes the issue.