### PR TITLE
fix(ngx-inform): pass dataType onto modal data property

### DIFF
--- a/libs/inform/README.md
+++ b/libs/inform/README.md
@@ -99,17 +99,17 @@ The `NgxModalService` provides a WCAG/ARIA compliant approach to the Angular CDK
 You can use the `NgxModalService` without any prior setup, but the `ngx-inform` package does provide the ability to provide a global configuration that can be applied for all modals. On top of that, you can provide default modals with your specific configuration.
 
 ``` ts
-		provideNgxModalConfiguration({
-            closeOnNavigation: true,
-            autoClose: true
-			modals: {
-				confirm: {
-					component: ConfirmModalComponent,
-					role: 'alertdialog',
-                    panelClass: 'panel-confirm',
-				},
-			},
-		}),
+provideNgxModalConfiguration({
+	closeOnNavigation: true,
+	autoClose: true,
+	modals: {
+		confirm: {
+			component: ConfirmModalComponent,
+			role: 'alertdialog',
+			panelClass: 'panel-confirm',
+		},
+	},
+}),
 ```
 
 Using the above configuration, we can set several properties that will be applied to the modals globally. These properties are:
@@ -149,43 +149,43 @@ When opening a modal we can overwrite all the globally and modal-specific config
 If we set a predefined modal, we can now call said modal using the `open` method on `NgxModalService`.
 
 ```ts
-		this.modalService
-			.open<'Confirm' | 'Deny'>({
-				type: 'confirm',
-				describedById: 'confirm-button',
-				labelledById: 'confirm-label',
-                data: {
-                    title: 'Please confirm your actions!'
-                }
-			})
-            .pipe(
-                tap(action => {
-                    if(action === 'Confirm') {
-                        // Perform confirm logic
-                    }
+this.modalService
+	.open<'Confirm' | 'Deny'>({
+		type: 'confirm',
+		describedById: 'confirm-button',
+		labelledById: 'confirm-label',
+		data: {
+			title: 'Please confirm your actions!'
+		}
+	})
+	.pipe(
+		tap(action => {
+			if(action === 'Confirm') {
+				// Perform confirm logic
+			}
 
-                    // Perform non-confirm logic
-                })
-            )
-			.subscribe();
+			// Perform non-confirm logic
+		})
+	)
+	.subscribe();
 ```
 #### Custom modal
 
 We can always create a custom modal for feature-specific use-cases. We do this by providing a component.
 
 ``` ts
-		this.modalService
-			.open<'Test'>({
-				component: ModalComponent,
-				label: 'Modal',
-				role: 'dialog',
-			})
-			.pipe(
-				tap((action) => {
-					if (action === 'Test') {
-						console.log('Hello!');
-					}
-				})
-			)
-			.subscribe();
+this.modalService
+	.open<'Test'>({
+		component: ModalComponent,
+		label: 'Modal',
+		role: 'dialog',
+	})
+	.pipe(
+		tap((action) => {
+			if (action === 'Test') {
+				console.log('Hello!');
+			}
+		})
+	)
+	.subscribe();
 ```

--- a/libs/inform/src/lib/services/modal/modal.service.ts
+++ b/libs/inform/src/lib/services/modal/modal.service.ts
@@ -41,8 +41,8 @@ export class NgxModalService {
 	 *
 	 * @param {NgxModalOptions<ActionType>} options - The modal options
 	 */
-	public open<ActionType extends string = string>(
-		options: NgxModalOptions<ActionType>
+	public open<ActionType extends string = string, DataType = any>(
+		options: NgxModalOptions<ActionType, DataType>
 	): Observable<ActionType> {
 		// Iben: If there still is an active subject running, the modal is still active and we early exit
 		if (!this.modalClosedSubject?.closed) {
@@ -58,10 +58,10 @@ export class NgxModalService {
 
 		// Iben: Fetch the type of component we wish to show
 		const configuration = this.configuration?.modals?.[options.type];
-		const component: Type<NgxModalAbstractComponent<ActionType>> =
+		const component: Type<NgxModalAbstractComponent<ActionType, DataType>> =
 			options.component ||
 			(this.configuration?.modals?.[options.type].component as Type<
-				NgxModalAbstractComponent<ActionType>
+				NgxModalAbstractComponent<ActionType, DataType>
 			>);
 
 		// Iben: Check if all the correct parameters are set and return NEVER when they're not correctly set
@@ -70,7 +70,7 @@ export class NgxModalService {
 		}
 
 		// Iben: Render the modal
-		const modal = this.createModalComponent<ActionType>(options, component);
+		const modal = this.createModalComponent<ActionType, DataType>(options, component);
 
 		// Iben: Return the modal action
 		return combineLatest([
@@ -168,9 +168,9 @@ export class NgxModalService {
 	 * @param options - The options of the modal
 	 * @param  component - The component we wish to render
 	 */
-	private createModalComponent<ActionType extends string = string>(
+	private createModalComponent<ActionType extends string = string, DataType = any>(
 		options: NgxModalOptions<ActionType>,
-		component: Type<NgxModalAbstractComponent<ActionType>>
+		component: Type<NgxModalAbstractComponent<ActionType, DataType>>
 	): NgxModalAbstractComponent<ActionType> {
 		const configuration = this.configuration?.modals?.[options.type];
 


### PR DESCRIPTION
The datatype can be passed onto the data property of the modal. This allows for proper typing.
![Screenshot 2024-09-19 at 15 09 08](https://github.com/user-attachments/assets/b87c9f23-e570-4f2b-96f9-eeeee2454822)
