### PR TITLE
fix(modal.service): verify the subject is not undefined when checking if a modal exists

### DIFF
--- a/libs/inform/src/lib/services/modal/modal.service.ts
+++ b/libs/inform/src/lib/services/modal/modal.service.ts
@@ -44,8 +44,8 @@ export class NgxModalService {
 	public open<ActionType extends string = string, DataType = any>(
 		options: NgxModalOptions<ActionType, DataType>
 	): Observable<ActionType> {
-		// Iben: If there still is an active subject running, the modal is still active and we early exit
-		if (!this.modalClosedSubject?.closed) {
+		// Iben: If there still is an active subject running, the modal is still active and we early exit.
+		if (this.modalClosedSubject !== undefined && !this.modalClosedSubject?.closed) {
 			console.warn(
 				'NgxInform: An active modal is currently displayed, close the active modal before opening a new one'
 			);


### PR DESCRIPTION
When the first ever modal is opened, the subject has not yet been initialised. It will therefore never open and aways throw the warning, as `!undefined?.close` is always `true`.

<img width="399" alt="Screenshot 2024-09-20 at 11 49 16" src="https://github.com/user-attachments/assets/606ae399-5d7e-4589-95e1-32cddfd83925">

