### PR TITLE
fix(ngx-inform): allow modal data set in the modal component to be emitted to the parent along with the type

### DIFF
--- a/apps/layout-test/src/app/app.component.ts
+++ b/apps/layout-test/src/app/app.component.ts
@@ -31,6 +31,7 @@ export class AppComponent {
 				component: ModalComponent,
 				label: 'Modal',
 				role: 'dialog',
+				panelClass: 'modal-panel',
 			})
 			.pipe(
 				tap((action) => {
@@ -44,11 +45,19 @@ export class AppComponent {
 
 	confirm(): void {
 		this.modalService
-			.open({
+			.open<{
+				type: 'Confirm';
+				data: string;
+			}>({
 				type: 'confirm',
 				describedById: 'id',
 				labelledById: 'hello',
 			})
+			.pipe(
+				tap((value) => {
+					console.log(value);
+				})
+			)
 			.subscribe();
 	}
 }

--- a/apps/layout-test/src/app/app.config.ts
+++ b/apps/layout-test/src/app/app.config.ts
@@ -31,8 +31,10 @@ export const appConfig: ApplicationConfig = {
 				confirm: {
 					component: ConfirmModalComponent,
 					role: 'alertdialog',
+					panelClass: 'modeeeeeeel-panel',
 				},
 			},
+			panelClass: 'modal-panelelelelele',
 		}),
 		provideRouter(routes),
 	],

--- a/apps/layout-test/src/modal/confirm.component.ts
+++ b/apps/layout-test/src/modal/confirm.component.ts
@@ -1,14 +1,33 @@
 import { Component } from '@angular/core';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { NgxModalAbstractComponent } from '@ngx/inform';
 
 @Component({
 	selector: 'confirm-modal',
 	template: `
 		Confirm this please
-		<button (click)="action.emit('Confirm')">Confirm</button>
+		<label for="confirm-modal-input">
+			Set some data to be passed to the component that opened this modal:
+		</label>
+		<input id="confirm-modal-input" type="text" [formControl]="inputForm" />
+		<button (click)="handleAction('Confirm')">Confirm</button>
 		<button (click)="close.emit()">Close</button>
 	`,
 	styleUrl: './modal.component.scss',
 	standalone: true,
+	imports: [ReactiveFormsModule],
 })
-export class ConfirmModalComponent extends NgxModalAbstractComponent<'Confirm'> {}
+export class ConfirmModalComponent extends NgxModalAbstractComponent<{
+	type: 'Confirm';
+	data: string;
+}> {
+	public inputForm: FormControl = new FormControl('', Validators.required);
+
+	handleAction(action: 'Confirm') {
+		if (this.inputForm.invalid) {
+			return;
+		}
+
+		this.action.emit({ type: action, data: this.inputForm.value });
+	}
+}

--- a/libs/inform/src/lib/abstracts/modal/modal.abstract.component.ts
+++ b/libs/inform/src/lib/abstracts/modal/modal.abstract.component.ts
@@ -1,10 +1,11 @@
 import { Directive, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { NgxModalActionType } from '../../types';
 
 /**
  * An abstract for the NgxModalService
  */
 @Directive()
-export class NgxModalAbstractComponent<ActionType extends string = string, DataType = any> {
+export class NgxModalAbstractComponent<ActionType extends NgxModalActionType, DataType = any> {
 	/**
 	 * Remove the modal on escape pressed
 	 */

--- a/libs/inform/src/lib/services/modal/modal.service.ts
+++ b/libs/inform/src/lib/services/modal/modal.service.ts
@@ -12,7 +12,7 @@ import {
 	tap,
 } from 'rxjs';
 
-import { NgxModalConfiguration, NgxModalOptions } from '../../types';
+import { NgxModalActionType, NgxModalConfiguration, NgxModalOptions } from '../../types';
 import { NgxModalConfigurationToken } from '../../tokens';
 import { NgxModalAbstractComponent } from '../../abstracts';
 
@@ -46,7 +46,7 @@ export class NgxModalService {
 	 *
 	 * @param {NgxModalOptions<ActionType>} options - The modal options
 	 */
-	public open<ActionType extends string = string, DataType = any>(
+	public open<ActionType extends NgxModalActionType = string, DataType = any>(
 		options: NgxModalOptions<ActionType, DataType>
 	): Observable<ActionType> {
 		// Iben: If a previous modal is still active, we early exit.
@@ -142,7 +142,7 @@ export class NgxModalService {
 	 * @param options - The options of the modal
 	 * @param  component - The component we wish to render
 	 */
-	private runARIAChecks<ActionType extends string = string>(
+	private runARIAChecks<ActionType extends NgxModalActionType>(
 		options: NgxModalOptions<ActionType>,
 		component: Type<NgxModalAbstractComponent<ActionType>>
 	): boolean {
@@ -173,7 +173,7 @@ export class NgxModalService {
 	 * @param options - The options of the modal
 	 * @param  component - The component we wish to render
 	 */
-	private createModalComponent<ActionType extends string = string, DataType = any>(
+	private createModalComponent<ActionType extends NgxModalActionType, DataType = any>(
 		options: NgxModalOptions<ActionType>,
 		component: Type<NgxModalAbstractComponent<ActionType, DataType>>
 	): NgxModalAbstractComponent<ActionType> {
@@ -213,7 +213,7 @@ export class NgxModalService {
 	 *
 	 * @param options - The options of the modal
 	 */
-	private hasRequiredDescription<ActionType extends string = string>(
+	private hasRequiredDescription<ActionType extends NgxModalActionType>(
 		options: NgxModalOptions<ActionType>
 	): boolean {
 		// Iben: If the options has provided a default type, we check based on the configuration role

--- a/libs/inform/src/lib/types/modal.types.ts
+++ b/libs/inform/src/lib/types/modal.types.ts
@@ -6,6 +6,13 @@ import { NgxModalAbstractComponent } from '../abstracts';
 
 export type NgxModalRole = 'dialog' | 'alertdialog';
 
+/**
+ * The type of action that should be emitted by the modal.
+ */
+export type NgxModalActionType<StringType extends string = string, EmitDataType = any> =
+	| StringType
+	| { type: StringType; data: EmitDataType };
+
 // Aria configuration
 interface NgxModalAriaLabelBaseOptions {
 	/**
@@ -86,12 +93,12 @@ interface NgxModalCDKModalConfiguration {
 
 // Global configuration
 
-export interface NgxModalComponentConfiguration<DataType = any> {
+export interface NgxModalComponentConfiguration<ActionType extends NgxModalActionType, DataType> {
 	/**
 	 * The component that should be rendered as the modal. This component must extend the
 	 * [`NgxModalAbstractComponent`](../abstracts/modal/modal.abstract.component.ts).
 	 */
-	component: Type<NgxModalAbstractComponent>;
+	component: Type<NgxModalAbstractComponent<ActionType, DataType>>;
 	/**
 	 * The role that should be applied to the modal.
 	 *
@@ -112,13 +119,16 @@ interface NgxModalBaseConfiguration {
 	/**
 	 * The global modals that were configured in the root of the application.
 	 */
-	modals?: Record<string, NgxModalComponentConfiguration & NgxModalGlobalCDKConfiguration>;
+	modals?: Record<
+		string,
+		NgxModalComponentConfiguration<NgxModalActionType, any> & NgxModalGlobalCDKConfiguration
+	>;
 }
 
 export type NgxModalConfiguration = NgxModalBaseConfiguration & NgxModalGlobalCDKConfiguration;
 
 // Modal options
-interface NgxModalBaseOptions<ActionsType extends string, DataType> {
+interface NgxModalBaseOptions<ActionType extends NgxModalActionType, DataType> {
 	/**
 	 * The name of a config object defined in the global config at the root of
 	 * the project.
@@ -133,7 +143,7 @@ interface NgxModalBaseOptions<ActionsType extends string, DataType> {
 	 *
 	 * This property will take precedence over the `type` property.
 	 */
-	component?: Type<NgxModalAbstractComponent<ActionsType, DataType>>;
+	component?: Type<NgxModalAbstractComponent<ActionType, DataType>>;
 	/**
 	 * The data that will be passed to the modal. This data will be accessible in the
 	 * provided component.
@@ -153,17 +163,17 @@ interface NgxModalBaseOptions<ActionsType extends string, DataType> {
 	describedById?: string;
 }
 
-interface NgxModalTypeOptions<ActionsType extends string, DataType>
-	extends NgxModalBaseOptions<ActionsType, DataType> {
+interface NgxModalTypeOptions<ActionType extends NgxModalActionType, DataType>
+	extends NgxModalBaseOptions<ActionType, DataType> {
 	type: string;
 	component?: undefined;
 	role?: undefined;
 }
 
-interface NgxModalComponentOptions<ActionsType extends string, DataType>
-	extends NgxModalBaseOptions<ActionsType, DataType> {
+interface NgxModalComponentOptions<ActionType extends NgxModalActionType, DataType>
+	extends NgxModalBaseOptions<ActionType, DataType> {
 	type?: undefined;
-	component: Type<NgxModalAbstractComponent<ActionsType>>;
+	component: Type<NgxModalAbstractComponent<ActionType, DataType>>;
 	/**
 	 * The role that should be applied to the modal.
 	 *
@@ -175,12 +185,12 @@ interface NgxModalComponentOptions<ActionsType extends string, DataType>
 	role: NgxModalRole;
 }
 
-export type NgxModalOptions<ActionsType extends string = string, DataType = any> =
-	| (NgxModalTypeOptions<ActionsType, DataType> &
+export type NgxModalOptions<ActionType extends NgxModalActionType = string, DataType = any> =
+	| (NgxModalTypeOptions<ActionType, DataType> &
 			NgxModalLabelAriaOptions &
 			NgxModalGlobalCDKConfiguration &
 			NgxModalCDKModalConfiguration)
-	| (NgxModalComponentOptions<ActionsType, DataType> &
+	| (NgxModalComponentOptions<ActionType, DataType> &
 			NgxModalLabelAriaOptions &
 			NgxModalGlobalCDKConfiguration &
 			NgxModalCDKModalConfiguration);


### PR DESCRIPTION

https://github.com/user-attachments/assets/eec21667-a9f5-42cf-b595-6bf86d0207be

