### PR TITLE
fix(ngx-layout): update change detection as soon as an item is toggled

### DIFF
--- a/libs/layout/src/lib/components/accordion/item/accordion-item.component.ts
+++ b/libs/layout/src/lib/components/accordion/item/accordion-item.component.ts
@@ -173,7 +173,7 @@ export class NgxAccordionItemComponent implements OnInit, AfterViewInit, OnDestr
 
 		// Iben: Listen to the open state of details and update the internal one
 		this.renderer.listen(this.detailsElement.nativeElement, 'toggle', (event: ToggleEvent) => {
-			this.isOpen = event.newState === 'open';
+			this.updateAccordionItemState(event.newState === 'open');
 		});
 	}
 


### PR DESCRIPTION
The open state would not be toggled correctly, only after blur.

**Behaviour before:**

https://github.com/user-attachments/assets/ca8dafb0-d594-40c2-9fa9-7d8e620f47cf

**Behaviour after:**

https://github.com/user-attachments/assets/9b36283b-34b9-433b-9d95-667737d77754

