### PR TITLE
fix(tests): adjust mock for new method

### DIFF
--- a/libs/angular/utils/src/lib/services/broadcast-channel/broadcast-channel.service.spec.ts
+++ b/libs/angular/utils/src/lib/services/broadcast-channel/broadcast-channel.service.spec.ts
@@ -224,7 +224,9 @@ describe('NgxBroadcastChannelService', () => {
 		let service: NgxBroadcastChannelService;
 
 		const windowService = windowServiceMock(undefined);
-		windowService.isBrowser = () => false;
+		windowService.runInBrowser = () => {
+			return;
+		};
 
 		beforeEach(() => {
 			service = new NgxBroadcastChannelService(windowService as any);


### PR DESCRIPTION
The mock for `runInBrowser` does not call the previously mocked `isBrowser`, instead align this mock with the method used by `initChannel`