### PR TITLE
fix(build): specify correct paths for ng-doc & ngx libs + linting

### DIFF
--- a/apps/cookies-test/project.json
+++ b/apps/cookies-test/project.json
@@ -1,110 +1,102 @@
 {
-  "name": "cookies-test",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "prefix": "app",
-  "sourceRoot": "apps/cookies-test/src",
-  "tags": [],
-  "targets": {
-    "build": {
-      "executor": "@ng-doc/builder:application",
-      "outputs": [
-        "{options.outputPath}"
-      ],
-      "options": {
-        "outputPath": "dist/apps/cookies-test",
-        "index": "apps/cookies-test/src/index.html",
-        "main": "apps/cookies-test/src/main.ts",
-        "polyfills": [
-          "zone.js"
-        ],
-        "tsConfig": "apps/cookies-test/tsconfig.app.json",
-        "inlineStyleLanguage": "scss",
-        "assets": [
-          {
-            "glob": "**/*",
-            "input": "node_modules/@ng-doc/app/assets",
-            "output": "assets/ng-doc/app"
-          },
-          {
-            "glob": "**/*",
-            "input": "node_modules/@ng-doc/ui-kit/assets",
-            "output": "assets/ng-doc/ui-kit"
-          },
-          {
-            "glob": "**/*",
-            "input": "ng-doc/cookies-test/assets",
-            "output": "assets/ng-doc"
-          },
-          "apps/cookies-test/src/favicon.ico",
-          "apps/cookies-test/src/assets"
-        ],
-        "styles": [
-          "node_modules/@ng-doc/app/styles/global.css",
-          "apps/cookies-test/src/styles.scss",
-          "node_modules/vanilla-cookieconsent/dist/cookieconsent.css"
-        ],
-        "scripts": [],
-        "allowedCommonJsDependencies": [
-          "@ng-doc/core"
-        ]
-      },
-      "configurations": {
-        "production": {
-          "budgets": [
-            {
-              "type": "initial",
-              "maximumWarning": "500kb",
-              "maximumError": "1mb"
-            },
-            {
-              "type": "anyComponentStyle",
-              "maximumWarning": "2kb",
-              "maximumError": "4kb"
-            }
-          ],
-          "outputHashing": "all"
-        },
-        "development": {
-          "buildOptimizer": false,
-          "optimization": false,
-          "vendorChunk": true,
-          "extractLicenses": false,
-          "sourceMap": true,
-          "namedChunks": true
-        }
-      },
-      "defaultConfiguration": "production"
-    },
-    "serve": {
-      "executor": "@ng-doc/builder:dev-server",
-      "configurations": {
-        "production": {
-          "buildTarget": "cookies-test:build:production"
-        },
-        "development": {
-          "buildTarget": "cookies-test:build:development"
-        }
-      },
-      "defaultConfiguration": "development"
-    },
-    "extract-i18n": {
-      "executor": "@angular-devkit/build-angular:extract-i18n",
-      "options": {
-        "buildTarget": "cookies-test:build"
-      }
-    },
-    "lint": {
-      "executor": "@nx/eslint:lint"
-    },
-    "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": [
-        "{workspaceRoot}/coverage/{projectRoot}"
-      ],
-      "options": {
-        "jestConfig": "apps/cookies-test/jest.config.ts"
-      }
-    }
-  }
+	"name": "cookies-test",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"prefix": "app",
+	"sourceRoot": "apps/cookies-test/src",
+	"tags": [],
+	"targets": {
+		"build": {
+			"executor": "@ng-doc/builder:application",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"outputPath": "dist/apps/cookies-test",
+				"index": "apps/cookies-test/src/index.html",
+				"browser": "apps/cookies-test/src/main.ts",
+				"polyfills": ["zone.js"],
+				"tsConfig": "apps/cookies-test/tsconfig.app.json",
+				"inlineStyleLanguage": "scss",
+				"assets": [
+					{
+						"glob": "**/*",
+						"input": "node_modules/@ng-doc/app/assets",
+						"output": "assets/ng-doc/app"
+					},
+					{
+						"glob": "**/*",
+						"input": "node_modules/@ng-doc/ui-kit/assets",
+						"output": "assets/ng-doc/ui-kit"
+					},
+					{
+						"glob": "**/*",
+						"input": "ng-doc/cookies-test/assets",
+						"output": "assets/ng-doc"
+					},
+					{
+						"glob": "**/*",
+						"input": "apps/cookies-test/public"
+					}
+				],
+				"styles": [
+					"node_modules/@ng-doc/app/styles/global.css",
+					"apps/cookies-test/src/styles.scss",
+					"node_modules/vanilla-cookieconsent/dist/cookieconsent.css"
+				],
+				"scripts": [],
+				"allowedCommonJsDependencies": ["@ng-doc/core"]
+			},
+			"configurations": {
+				"production": {
+					"budgets": [
+						{
+							"type": "initial",
+							"maximumWarning": "500kb",
+							"maximumError": "2mb"
+						},
+						{
+							"type": "anyComponentStyle",
+							"maximumWarning": "2kb",
+							"maximumError": "4kb"
+						}
+					],
+					"outputHashing": "all"
+				},
+				"development": {
+					"optimization": false,
+					"extractLicenses": false,
+					"sourceMap": true,
+					"namedChunks": true
+				}
+			},
+			"defaultConfiguration": "production"
+		},
+		"serve": {
+			"executor": "@ng-doc/builder:dev-server",
+			"configurations": {
+				"production": {
+					"buildTarget": "cookies-test:build:production"
+				},
+				"development": {
+					"buildTarget": "cookies-test:build:development"
+				}
+			},
+			"defaultConfiguration": "development"
+		},
+		"extract-i18n": {
+			"executor": "@angular-devkit/build-angular:extract-i18n",
+			"options": {
+				"buildTarget": "cookies-test:build"
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint"
+		},
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "apps/cookies-test/jest.config.ts"
+			}
+		}
+	}
 }

--- a/apps/cookies-test/src/app/app.component.ts
+++ b/apps/cookies-test/src/app/app.component.ts
@@ -2,12 +2,9 @@ import { NgDocRootComponent, NgDocNavbarComponent, NgDocSidebarComponent } from 
 import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { CookieAlertComponent } from './cookies.component';
-import {
-	NgxCookieService,
-	NgxCookiesFallbackComponentToken,
-	NgxHasCookieDirective,
-} from '@ngx/cookies';
+import { NgxCookieService, NgxCookiesFallbackComponentToken } from '@ngx/cookies';
 import { NgxStorageService } from '@ngx/utils';
 
 @Component({
@@ -16,7 +13,7 @@ import { NgxStorageService } from '@ngx/utils';
 	styleUrl: './app.component.scss',
 	imports: [
 		CommonModule,
-		NgxHasCookieDirective,
+		RouterModule,
 		NgDocRootComponent,
 		NgDocNavbarComponent,
 		NgDocSidebarComponent,

--- a/apps/cookies-test/tsconfig.app.json
+++ b/apps/cookies-test/tsconfig.app.json
@@ -1,6 +1,12 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+		"paths": {
+			"@ng-doc/generated": ["././ng-doc/cookies-test/index.ts"],
+			"@ng-doc/generated/*": ["./ng-doc/cookies-test/*"],
+			"@ngx/cookies": ["libs/angular/cookies/src/index.ts"],
+			"@ngx/utils": ["libs/angular/utils/src/public-api.ts"],
+    }
   },
 	"extends": "../../tsconfig.json",
 	"files": ["src/main.ts"],


### PR DESCRIPTION
- Align project.json with its source (`apps/docs/project.json`)
- Fix syntax error in project.json
- Linting
- Add missing RouterModule
- Overwrite paths in tsconfig because this project also builds with ng-doc and outputs to a separate directory