### PR TITLE
fix(docs): reload on docs pages not working

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Build the documentation
       - name: Build Documentation
-        run: npx nx run docs:build --prerender=true --server="apps/docs/server.ts"
+        run: npx nx run docs:build --prerender=true --server="apps/docs/server.ts" --baseHref="./"
 
   
       - name: Upload static files as artifact

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -16,7 +16,6 @@
 				"polyfills": ["zone.js"],
 				"tsConfig": "apps/docs/tsconfig.app.json",
 				"inlineStyleLanguage": "scss",
-				"baseHref": "./",
 				"assets": [
 					{
 						"glob": "**/*",


### PR DESCRIPTION
**Description**
Changing the baseHref in the project.json for the docs caused a refresh issue. To address this, the baseHref is now included only in the build command for the GitHub Pages deployment. This ensures the refresh functionality works correctly without breaking the deployment process.
