### PR TITLE
fix(docs): posible fix broken-navigation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Build the documentation
       - name: Build Documentation
-        run: npx nx run docs:build --prerender=true --server="apps/docs/server.ts" --baseHref="./"
+        run: npx nx run docs:build --prerender=true --server="apps/docs/server.ts" --baseHref="https://open-source.studiohyperdrive.be/"
 
   
       - name: Upload static files as artifact


### PR DESCRIPTION
**Description**
This PR resolves the issue with broken navigation on GitHub Pages. I attempted to remove the trailing slash using the Angular Router, but it seems the router does not apply when generating static HTML files for GitHub Pages.

If [this feature request](https://github.com/angular/angular-cli/issues/29173) every gets implemented, we should follow it's approach.
