### PR TITLE
docs(ngx-inform): split introduction page into sections for different audiences

### DIFF
--- a/apps/docs/src/app/pages/docs/angular/inform/introduction/index.md
+++ b/apps/docs/src/app/pages/docs/angular/inform/introduction/index.md
@@ -2,9 +2,18 @@
 keyword: IntroductionPage
 ---
 
-`ngx-inform` is a collection of Angular flows related to informing end-users.
+## For Organisations
 
-`ngx-inform` is a package to help facilitate common user information use-cases such as tooltips, toasts and snackbars.
+In modern web applications, effectively communicating with users is crucial. The `@studiohyperdrive/ngx-inform` package provides a comprehensive solution for user notifications and interactions. It helps organisations by:
+
+- **Enhanced User Experience**: Provides clear and consistent ways to communicate with users through tooltips, modals, and notifications
+- **Accessibility Compliance**: Ensures all notification components are WCAG compliant, making your application accessible to all users
+- **Reduced Development Effort**: Offers ready-to-use, tested components for common notification patterns
+- **Consistent Communication**: Standardizes how your application communicates with users across different features
+- **Flexible Integration**: Easily adapts to your application's design system and requirements
+- **Improved User Guidance**: Helps users understand complex features through tooltips and contextual help
+
+## For Developers
 
 At its core, `ngx-inform` is build to be WCAG and ARIA compliant, and will throw errors whenever the necessary setup has not been provided to ensure said compliancy.
 


### PR DESCRIPTION
**Description**
split introduction page into sections for different audiences -- closes #307

**Requirements**

- [x] Correct label have been assigned
- [x] Project has been assigned
- [x] Milestone has been (created/)assigned
