### PR TITLE
fix(ngx-utils): Fix incorrect handling of form value in QueryParamSync

### DIFF
--- a/libs/angular/utils/src/lib/abstracts/query-param-form-sync/query-param-form-sync.component.abstract.ts
+++ b/libs/angular/utils/src/lib/abstracts/query-param-form-sync/query-param-form-sync.component.abstract.ts
@@ -86,6 +86,11 @@ export abstract class NgxQueryParamFormSyncComponent<
 						value = this.unscrambleParams(value);
 					}
 
+					//Iben: If the entire object is empty, we early exit and do not set the form
+					if (Object.keys(value).length === 0) {
+						return;
+					}
+
 					// Iben: Set the current form value
 					this.form.setValue(value);
 				}),


### PR DESCRIPTION
**Description**
We double check if the initial value has keys before setting the value. A patchValue is avoided as we do not want to mix previous state and new state at the initial sync.

**Requirements**

- [x] Correct label have been assigned
- [x] Project has been assigned
- [x] Milestone has been (created/)assigned

**Attachments**
_Attach a video/screenshot/other attachment if necessary_
